### PR TITLE
Bind Datastore Search To Resource Type

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/torch/consent/ConsentHandler.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/consent/ConsentHandler.java
@@ -96,8 +96,7 @@ public class ConsentHandler {
         Query query = Query.of(type, QueryParams.of("_profile", stringValue(CDS_CONSENT_PROFILE_URL))
                 .appendParams(batch.compartmentSearchParam(type)));
 
-        return dataStore.search(query)
-                .cast(Consent.class)
+        return dataStore.search(query, Consent.class)
                 .doOnSubscribe(subscription -> logger.trace("Fetching resources for batch: {}", batch.bundles().keySet()))
                 .doOnNext(resource -> logger.trace("Consent resource with id {} fetched for ConsentBuild", resource.getIdPart()))
                 .flatMap(consent -> {
@@ -167,8 +166,7 @@ public class ConsentHandler {
 
         Query query = Query.of(type, QueryParams.of("_profile", stringValue(CDS_ENCOUNTER_PROFILE_URL))
                 .appendParams(updateBatch.compartmentSearchParam(type)));
-        Flux<Encounter> allEncountersFlux = dataStore.search(query)
-                .cast(Encounter.class)
+        Flux<Encounter> allEncountersFlux = dataStore.search(query, Encounter.class)
                 .doOnSubscribe(subscription -> logger.trace("Fetching encounters for batch: {}", updateBatch.patientIds()))
                 .doOnNext(encounter -> logger.trace("Encounter fetched: {}", encounter.getIdElement().getIdPart()));
 

--- a/src/main/java/de/medizininformatikinitiative/torch/cql/CqlClient.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/cql/CqlClient.java
@@ -6,6 +6,7 @@ import de.medizininformatikinitiative.torch.service.DataStore;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.MeasureReport;
 import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.Patient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
@@ -42,9 +43,9 @@ public class CqlClient {
                 .map(CqlClient::extractSubjectListId)
                 .map(CqlClient::createPatientQuery)
                 .flux()
-                .flatMap(dataStore::search)
-                .flatMap(resource -> {
-                    var id = resource.getIdPart();
+                .flatMap(query -> dataStore.search(query, Patient.class))
+                .flatMap(patient -> {
+                    var id = patient.getIdPart();
                     return id == null ? Flux.error(new RuntimeException("Encountered Patient Resource without ID")) : Flux.just(id);
                 });
     }

--- a/src/test/java/de/medizininformatikinitiative/torch/DirectResourceLoaderIT.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/DirectResourceLoaderIT.java
@@ -10,9 +10,9 @@ import de.medizininformatikinitiative.torch.model.management.PatientBatch;
 import de.medizininformatikinitiative.torch.model.mapping.DseMappingTreeBase;
 import de.medizininformatikinitiative.torch.service.CrtdlValidatorService;
 import de.medizininformatikinitiative.torch.setup.ContainerManager;
+import org.hl7.fhir.r4.model.DomainResource;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Patient;
-import org.hl7.fhir.r4.model.Resource;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -79,11 +79,24 @@ public class DirectResourceLoaderIT {
         PatientBatch batch = PatientBatch.of("1", "2");
         Query query = new Query("Patient", EMPTY); // Basic query setup
 
-        Flux<Resource> result = dLoader.executeQueryWithBatch(batch, query);
+        Flux<DomainResource> result = dLoader.executeQueryWithBatch(batch, query);
 
         StepVerifier.create(result)
-                .expectNextMatches(resource -> resource instanceof Patient)
-                .expectNextMatches(resource -> resource instanceof Patient)
+                .expectNextMatches(Patient.class::isInstance)
+                .expectNextMatches(Patient.class::isInstance)
+                .verifyComplete();
+    }
+
+    @Test
+    void testExecuteQueryWithObservation() {
+        PatientBatch batch = PatientBatch.of("1", "2");
+        Query query = new Query("Observation", EMPTY); // Basic query setup
+
+        Flux<DomainResource> result = dLoader.executeQueryWithBatch(batch, query);
+
+        StepVerifier.create(result)
+                .expectNextMatches(Observation.class::isInstance)
+                .expectNextMatches(Observation.class::isInstance)
                 .verifyComplete();
     }
 


### PR DESCRIPTION
Instead of casting later in the chain, datastore takes a resource class parameter and casts to it.