### PR TITLE
Simplify AnnotatedAttributeGroupTest

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/torch/model/crtdl/annotated/AnnotatedAttributeGroup.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/model/crtdl/annotated/AnnotatedAttributeGroup.java
@@ -96,10 +96,6 @@ public record AnnotatedAttributeGroup(
         return new AnnotatedAttributeGroup(name, id, resourceType, groupReference, attributes, filter, compiledFilter, includeReferenceOnly);
     }
 
-    public String resourceType() {
-        return attributes.getFirst().attributeRef().split("\\.")[0];
-    }
-
     public boolean hasMustHave() {
         return attributes.stream().anyMatch(AnnotatedAttribute::mustHave);
     }
@@ -110,4 +106,3 @@ public record AnnotatedAttributeGroup(
     }
 
 }
-

--- a/src/test/java/de/medizininformatikinitiative/torch/model/crtdl/annotated/AnnotatedAttributeGroupTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/model/crtdl/annotated/AnnotatedAttributeGroupTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AnnotatedAttributeGroupTest {
+    
     static final LocalDate DATE_START = LocalDate.parse("2023-01-01");
     static final LocalDate DATE_END = LocalDate.parse("2023-12-31");
     static final Code CODE1 = new Code("system1", "code1");
@@ -40,12 +41,12 @@ class AnnotatedAttributeGroupTest {
         void oneCode() {
             when(mappingTreeBase.expand("system1", "code1")).thenReturn(Stream.of("code1"));
             var tokenFilter = new Filter("token", "code", List.of(CODE1));
-            var attributeGroup = new AnnotatedAttributeGroup("test", "Observation", "groupRef", List.of(new AnnotatedAttribute("Observation.name", "Observation.name", "Observation.name", false)), List.of(tokenFilter), null);
+            var attributeGroup = new AnnotatedAttributeGroup("test", "Observation", "groupRef", List.of(), List.of(tokenFilter), null);
 
             var result = attributeGroup.queries(mappingTreeBase, "Observation");
 
             assertThat(result).containsExactly(
-                    new Query("Observation", QueryParams.of("code", codeValue(CODE1)).appendParam("_profile:below", stringValue("groupRef")))
+                    Query.of("Observation", QueryParams.of("code", codeValue(CODE1)).appendParam("_profile:below", stringValue("groupRef")))
             );
         }
 
@@ -54,32 +55,32 @@ class AnnotatedAttributeGroupTest {
             when(mappingTreeBase.expand("system1", "code1")).thenReturn(Stream.of("code1"));
             when(mappingTreeBase.expand("system2", "code2")).thenReturn(Stream.of("code2"));
             var tokenFilter = new Filter("token", "code", List.of(CODE1, CODE2));
-            var attributeGroup = new AnnotatedAttributeGroup("test", "Observation", "groupRef", List.of(new AnnotatedAttribute("Observation.name", "Observation.name", "Observation.name", false)), List.of(tokenFilter), null);
+            var attributeGroup = new AnnotatedAttributeGroup("test", "Observation", "groupRef", List.of(), List.of(tokenFilter), null);
 
             var result = attributeGroup.queries(mappingTreeBase, "Observation");
 
             assertThat(result).containsExactly(
-                    new Query("Observation", QueryParams.of("code", codeValue(CODE1)).appendParam("_profile:below", stringValue("groupRef"))),
-                    new Query("Observation", QueryParams.of("code", codeValue(CODE2)).appendParam("_profile:below", stringValue("groupRef")))
+                    Query.of("Observation", QueryParams.of("code", codeValue(CODE1)).appendParam("_profile:below", stringValue("groupRef"))),
+                    Query.of("Observation", QueryParams.of("code", codeValue(CODE2)).appendParam("_profile:below", stringValue("groupRef")))
             );
         }
 
         @Test
         void dateFilter() {
             var dateFilter = new Filter("date", "date", DATE_START, DATE_END);
-            var attributeGroup = new AnnotatedAttributeGroup("test", "Observation", "groupRef", List.of(new AnnotatedAttribute("Observation.name", "Observation.name", "Observation.name", false)), List.of(dateFilter), null);
+            var attributeGroup = new AnnotatedAttributeGroup("test", "Observation", "groupRef", List.of(), List.of(dateFilter), null);
 
             var result = attributeGroup.queries(mappingTreeBase, "Observation");
 
             assertThat(result).containsExactly(
-                    new Query("Observation", QueryParams.of("date", dateValue(GREATER_EQUAL, DATE_START)).appendParam("date", dateValue(LESS_EQUAL, DATE_END)).appendParam("_profile:below", stringValue("groupRef")))
+                    Query.of("Observation", QueryParams.of("date", dateValue(GREATER_EQUAL, DATE_START)).appendParam("date", dateValue(LESS_EQUAL, DATE_END)).appendParam("_profile:below", stringValue("groupRef")))
             );
         }
 
         @Test
         void filtersIgnoredForPatient() {
             var dateFilter = new Filter("date", "date", DATE_START, DATE_END);
-            var attributeGroup = new AnnotatedAttributeGroup("test", "Observation", "groupRef", List.of(new AnnotatedAttribute("Patient.name", "Patient.name", "Patient.name", false)), List.of(dateFilter), null);
+            var attributeGroup = new AnnotatedAttributeGroup("test", "Observation", "groupRef", List.of(), List.of(dateFilter), null);
 
             var result = attributeGroup.queries(mappingTreeBase, "Patient");
 


### PR DESCRIPTION
Removed attribute that was only needed for resource type calculation. However the resource type is known anyway. So also removed it's calculation.