### PR TITLE
Refactor ConsentCode

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/torch/consent/ConsentCalculator.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/consent/ConsentCalculator.java
@@ -1,10 +1,10 @@
 package de.medizininformatikinitiative.torch.consent;
 
 import de.medizininformatikinitiative.torch.exceptions.ConsentViolatedException;
-import de.medizininformatikinitiative.torch.model.consent.ConsentCode;
 import de.medizininformatikinitiative.torch.model.consent.ConsentProvisions;
 import de.medizininformatikinitiative.torch.model.consent.NonContinuousPeriod;
 import de.medizininformatikinitiative.torch.model.consent.Provision;
+import de.medizininformatikinitiative.torch.model.management.TermCode;
 import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
@@ -36,9 +36,9 @@ public class ConsentCalculator {
      * @param consentCodes      the consentcodes relevant to type of consent to calculate
      * @return a map from consent code to {@link NonContinuousPeriod} representing allowed periods for that code
      */
-    Map<ConsentCode, NonContinuousPeriod> subtractAndMergeByCode(
+    Map<TermCode, NonContinuousPeriod> subtractAndMergeByCode(
             List<ConsentProvisions> consentProvisions,
-            Set<ConsentCode> consentCodes
+            Set<TermCode> consentCodes
     ) {
         // Flatten all provisions, filter relevant codes
         List<Provision> relevantProvisions = consentProvisions.stream()
@@ -55,7 +55,7 @@ public class ConsentCalculator {
                 .filter(p -> !p.permit())
                 .toList();
 
-        Map<ConsentCode, NonContinuousPeriod> result = new HashMap<>();
+        Map<TermCode, NonContinuousPeriod> result = new HashMap<>();
 
         // Apply permits first
         for (Provision p : permits) {
@@ -69,7 +69,7 @@ public class ConsentCalculator {
             result.put(p.code(), existing.substract(p.period()));
         }
 
-        Map<ConsentCode, NonContinuousPeriod> filtered = result.entrySet().stream()
+        Map<TermCode, NonContinuousPeriod> filtered = result.entrySet().stream()
                 .filter(e -> !e.getValue().isEmpty())
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
@@ -89,7 +89,7 @@ public class ConsentCalculator {
      * @return a {@link NonContinuousPeriod} representing the intersection of all provided periods
      * @throws ConsentViolatedException if there are no consent periods or if the intersection is empty
      */
-    public NonContinuousPeriod intersectConsent(Map<ConsentCode, NonContinuousPeriod> consentsByCode) throws ConsentViolatedException {
+    public NonContinuousPeriod intersectConsent(Map<TermCode, NonContinuousPeriod> consentsByCode) throws ConsentViolatedException {
         if (consentsByCode.isEmpty()) {
             throw new ConsentViolatedException("No consent periods found");
         }
@@ -120,7 +120,7 @@ public class ConsentCalculator {
      * @return a map from patient ID to {@link NonContinuousPeriod} representing their effective consent periods
      */
     public Map<String, NonContinuousPeriod> calculateConsent(
-            Set<ConsentCode> consentCodes,
+            Set<TermCode> consentCodes,
             Map<String, List<ConsentProvisions>> consentsByPatient
     ) {
         return consentsByPatient.entrySet().stream()

--- a/src/main/java/de/medizininformatikinitiative/torch/consent/ConsentCodeMapper.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/consent/ConsentCodeMapper.java
@@ -2,7 +2,7 @@ package de.medizininformatikinitiative.torch.consent;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import de.medizininformatikinitiative.torch.model.consent.ConsentCode;
+import de.medizininformatikinitiative.torch.model.management.TermCode;
 
 import java.io.File;
 import java.io.IOException;
@@ -16,7 +16,7 @@ import java.util.stream.Stream;
  */
 public class ConsentCodeMapper {
 
-    private final Map<ConsentCode, List<ConsentCode>> consentMap;
+    private final Map<TermCode, List<TermCode>> consentMap;
     private final ObjectMapper objectMapper;
 
 
@@ -36,7 +36,7 @@ public class ConsentCodeMapper {
             JsonNode context = consent.get("context");
             String system = context.get("system").asText();
             String keyCode = consent.get("key").get("code").asText();
-            List<ConsentCode> relevantCodes = new ArrayList<>();
+            List<TermCode> relevantCodes = new ArrayList<>();
             JsonNode fixedCriteria = consent.get("fixedCriteria");
             if (fixedCriteria != null) {
                 for (JsonNode criterion : fixedCriteria) {
@@ -44,16 +44,16 @@ public class ConsentCodeMapper {
 
                     while (values.hasNext()) {
                         JsonNode value = values.next();
-                        relevantCodes.add(new ConsentCode(value.get("system").asText(), value.get("code").asText()));
+                        relevantCodes.add(new TermCode(value.get("system").asText(), value.get("code").asText()));
                     }
                 }
             }
 
-            consentMap.put(new ConsentCode(system, keyCode), relevantCodes);
+            consentMap.put(new TermCode(system, keyCode), relevantCodes);
         }
     }
 
-    public Set<ConsentCode> getCombinedCodes(ConsentCode key) {
+    public Set<TermCode> getCombinedCodes(TermCode key) {
         return new HashSet<>(consentMap.getOrDefault(key, Collections.emptyList()));
     }
 
@@ -64,10 +64,10 @@ public class ConsentCodeMapper {
      * @param keys codes that could be expandable
      * @return a set of combined codes and non expandable codes
      */
-    public Set<ConsentCode> addCombinedCodes(Set<ConsentCode> keys) {
+    public Set<TermCode> addCombinedCodes(Set<TermCode> keys) {
         return keys.stream()
                 .flatMap(key -> {
-                    Set<ConsentCode> combined = getCombinedCodes(key);
+                    Set<TermCode> combined = getCombinedCodes(key);
                     // if there are no combined codes, include the original key
                     return combined.isEmpty() ? Stream.of(key) : combined.stream();
                 })

--- a/src/main/java/de/medizininformatikinitiative/torch/consent/ConsentFetcher.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/consent/ConsentFetcher.java
@@ -2,10 +2,10 @@ package de.medizininformatikinitiative.torch.consent;
 
 import de.medizininformatikinitiative.torch.exceptions.ConsentViolatedException;
 import de.medizininformatikinitiative.torch.exceptions.PatientIdNotFoundException;
-import de.medizininformatikinitiative.torch.model.consent.ConsentCode;
 import de.medizininformatikinitiative.torch.model.consent.ConsentProvisions;
 import de.medizininformatikinitiative.torch.model.fhir.Query;
 import de.medizininformatikinitiative.torch.model.management.PatientBatch;
+import de.medizininformatikinitiative.torch.model.management.TermCode;
 import de.medizininformatikinitiative.torch.service.DataStore;
 import de.medizininformatikinitiative.torch.util.ResourceUtils;
 import org.hl7.fhir.r4.model.Consent;
@@ -66,7 +66,7 @@ public class ConsentFetcher {
      * @param batch A list of patient IDs to process in this batch.
      * @return A {@link Flux} emitting maps containing consent information structured by patient ID and consent codes.
      */
-    public Mono<Map<String, List<ConsentProvisions>>> fetchConsentInfo(Set<ConsentCode> codes, PatientBatch batch) {
+    public Mono<Map<String, List<ConsentProvisions>>> fetchConsentInfo(Set<TermCode> codes, PatientBatch batch) {
         logger.debug("Starting to build consent info for codes {} and {} patients", codes, batch.ids().size());
 
         return dataStore.search(getConsentQuery(batch), Consent.class)

--- a/src/main/java/de/medizininformatikinitiative/torch/consent/ConsentHandler.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/consent/ConsentHandler.java
@@ -1,8 +1,8 @@
 package de.medizininformatikinitiative.torch.consent;
 
-import de.medizininformatikinitiative.torch.model.consent.ConsentCode;
 import de.medizininformatikinitiative.torch.model.consent.PatientBatchWithConsent;
 import de.medizininformatikinitiative.torch.model.management.PatientBatch;
+import de.medizininformatikinitiative.torch.model.management.TermCode;
 import de.medizininformatikinitiative.torch.service.DataStore;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
@@ -61,8 +61,8 @@ public class ConsentHandler {
      * @param batch        the batch of patient IDs to process
      * @return a {@link Mono} emitting a {@link PatientBatchWithConsent} containing patients with valid consent periods
      */
-    public Mono<PatientBatchWithConsent> fetchAndBuildConsentInfo(Set<ConsentCode> consentCodes, PatientBatch batch) {
-        Set<ConsentCode> expandedConsentCodes = consentCodeMapper.addCombinedCodes(consentCodes);
+    public Mono<PatientBatchWithConsent> fetchAndBuildConsentInfo(Set<TermCode> consentCodes, PatientBatch batch) {
+        Set<TermCode> expandedConsentCodes = consentCodeMapper.addCombinedCodes(consentCodes);
         return consentFetcher.fetchConsentInfo(expandedConsentCodes, batch)
                 .flatMap(consentProvisions ->
                         consentAdjuster.fetchEncounterAndAdjustByEncounter(batch, consentProvisions)

--- a/src/main/java/de/medizininformatikinitiative/torch/consent/ProvisionExtractor.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/consent/ProvisionExtractor.java
@@ -2,9 +2,9 @@ package de.medizininformatikinitiative.torch.consent;
 
 import de.medizininformatikinitiative.torch.exceptions.ConsentViolatedException;
 import de.medizininformatikinitiative.torch.exceptions.PatientIdNotFoundException;
-import de.medizininformatikinitiative.torch.model.consent.ConsentCode;
 import de.medizininformatikinitiative.torch.model.consent.ConsentProvisions;
 import de.medizininformatikinitiative.torch.model.consent.Provision;
+import de.medizininformatikinitiative.torch.model.management.TermCode;
 import de.medizininformatikinitiative.torch.util.ResourceUtils;
 import org.hl7.fhir.r4.model.*;
 import org.slf4j.Logger;
@@ -37,7 +37,7 @@ public class ProvisionExtractor {
      * @return a {@code Map} where each key is a valid code and the value is a list of {@link Period} objects
      * associated with that code
      */
-    public ConsentProvisions extractProvisionsPeriodByCode(Consent consent, Set<ConsentCode> requiredCodes) throws ConsentViolatedException, PatientIdNotFoundException {
+    public ConsentProvisions extractProvisionsPeriodByCode(Consent consent, Set<TermCode> requiredCodes) throws ConsentViolatedException, PatientIdNotFoundException {
         List<Provision> provisions = new ArrayList<>();
         if (consent.getDateTimeElement().isEmpty()) {
             throw new ConsentViolatedException("Consent resource " + consent.getId() + " has no valid consent date");
@@ -49,7 +49,7 @@ public class ProvisionExtractor {
             for (CodeableConcept cc : provision.getCode()) {
                 // Iterate over all codings
                 for (Coding coding : cc.getCoding()) {
-                    ConsentCode code = new ConsentCode(coding.getSystem(), coding.getCode());
+                    TermCode code = new TermCode(coding.getSystem(), coding.getCode());
                     if (!requiredCodes.contains(code)) continue;
 
                     Period period = provision.getPeriod();

--- a/src/main/java/de/medizininformatikinitiative/torch/model/consent/Provision.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/model/consent/Provision.java
@@ -1,10 +1,11 @@
 package de.medizininformatikinitiative.torch.model.consent;
 
+import de.medizininformatikinitiative.torch.model.management.TermCode;
 import org.hl7.fhir.r4.model.Consent;
 
 import static java.util.Objects.requireNonNull;
 
-public record Provision(ConsentCode code, Period period, boolean permit) {
+public record Provision(TermCode code, Period period, boolean permit) {
     public Provision {
         requireNonNull(code);
         requireNonNull(period);
@@ -12,7 +13,7 @@ public record Provision(ConsentCode code, Period period, boolean permit) {
 
     public static Provision fromHapi(Consent.ProvisionComponent provision) {
         boolean permit = provision.getType().equals(Consent.ConsentProvisionType.PERMIT);
-        ConsentCode consentCode = new ConsentCode(provision.getCode().getFirst().getCoding().getFirst().getSystem(), provision.getCode().getFirst().getCoding().getFirst().getCode());
+        TermCode consentCode = new TermCode(provision.getCode().getFirst().getCoding().getFirst().getSystem(), provision.getCode().getFirst().getCoding().getFirst().getCode());
         return new Provision(consentCode, Period.fromHapi(provision.getPeriod()), permit);
     }
 }

--- a/src/main/java/de/medizininformatikinitiative/torch/model/crtdl/annotated/AnnotatedCrtdl.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/model/crtdl/annotated/AnnotatedCrtdl.java
@@ -1,7 +1,7 @@
 package de.medizininformatikinitiative.torch.model.crtdl.annotated;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import de.medizininformatikinitiative.torch.model.consent.ConsentCode;
+import de.medizininformatikinitiative.torch.model.management.TermCode;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -19,12 +19,12 @@ public record AnnotatedCrtdl(JsonNode cohortDefinition, AnnotatedDataExtraction 
         requireNonNull(dataExtraction);
     }
 
-    public Optional<Set<ConsentCode>> consentKey() {
+    public Optional<Set<TermCode>> consentKey() {
         JsonNode inclusionCriteria = cohortDefinition.get("inclusionCriteria");
         if (inclusionCriteria == null || !inclusionCriteria.isArray()) {
             return Optional.empty();
         }
-        Set<ConsentCode> codes = StreamSupport.stream(inclusionCriteria.spliterator(), false)
+        Set<TermCode> codes = StreamSupport.stream(inclusionCriteria.spliterator(), false)
                 .filter(JsonNode::isArray)
                 .flatMap(group -> StreamSupport.stream(group.spliterator(), false))
                 .filter(criteria -> "Einwilligung".equals(criteria.path("context").path("code").asText(null)))
@@ -36,7 +36,7 @@ public record AnnotatedCrtdl(JsonNode cohortDefinition, AnnotatedDataExtraction 
                                     String system = tc.path("system").asText(null);
                                     String code = tc.path("code").asText(null);
                                     if (system != null && code != null) {
-                                        return new ConsentCode(system, code);
+                                        return new TermCode(system, code);
                                     } else {
                                         return null; // skip nodes missing data
                                     }

--- a/src/main/java/de/medizininformatikinitiative/torch/model/management/TermCode.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/model/management/TermCode.java
@@ -1,7 +1,7 @@
-package de.medizininformatikinitiative.torch.model.consent;
+package de.medizininformatikinitiative.torch.model.management;
 
-public record ConsentCode(String system, String code) {
-    public ConsentCode {
+public record TermCode(String system, String code) {
+    public TermCode {
         if (system == null || system.isBlank()) {
             throw new IllegalArgumentException("system must not be null or blank");
         }

--- a/src/test/java/de/medizininformatikinitiative/torch/consent/ConsentAdjusterTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/consent/ConsentAdjusterTest.java
@@ -1,11 +1,11 @@
 package de.medizininformatikinitiative.torch.consent;
 
-import de.medizininformatikinitiative.torch.model.consent.ConsentCode;
 import de.medizininformatikinitiative.torch.model.consent.ConsentProvisions;
 import de.medizininformatikinitiative.torch.model.consent.Period;
 import de.medizininformatikinitiative.torch.model.consent.Provision;
 import de.medizininformatikinitiative.torch.model.fhir.Query;
 import de.medizininformatikinitiative.torch.model.management.PatientBatch;
+import de.medizininformatikinitiative.torch.model.management.TermCode;
 import de.medizininformatikinitiative.torch.service.DataStore;
 import org.hl7.fhir.r4.model.Encounter;
 import org.junit.jupiter.api.BeforeEach;
@@ -55,7 +55,7 @@ class ConsentAdjusterUnitTest {
 
     @Test
     void testAdjustProvisions_noEncounters_returnsSame() {
-        Provision p1 = new Provision(new ConsentCode("s1", "code1"), Period.of(LocalDate.of(2025, 9, 10), LocalDate.of(2025, 9, 30)), true);
+        Provision p1 = new Provision(new TermCode("s1", "code1"), Period.of(LocalDate.of(2025, 9, 10), LocalDate.of(2025, 9, 30)), true);
         ConsentProvisions consent = new ConsentProvisions("patient1", null, List.of(p1));
 
         Map<String, List<ConsentProvisions>> updated = adjuster.adjustProvisionsByEncounters(
@@ -71,7 +71,7 @@ class ConsentAdjusterUnitTest {
     void testFetchAndAdjust_skipsEncounterWithoutPatientId() {
         PatientBatch batch = new PatientBatch(List.of("patient1"));
 
-        Provision p1 = new Provision(new ConsentCode("s1", "code1"), Period.of(LocalDate.of(2025, 9, 10), LocalDate.of(2025, 9, 30)), true);
+        Provision p1 = new Provision(new TermCode("s1", "code1"), Period.of(LocalDate.of(2025, 9, 10), LocalDate.of(2025, 9, 30)), true);
         ConsentProvisions consent = new ConsentProvisions("patient1", null, List.of(p1));
 
         // Encounter that will throw PatientIdNotFoundException
@@ -95,7 +95,7 @@ class ConsentAdjusterUnitTest {
 
     @Test
     void testAdjustProvisions_singleOverlap_shiftsStart() {
-        Provision p1 = new Provision(new ConsentCode("s1", "code1"), Period.of(LocalDate.of(2025, 9, 10), LocalDate.of(2025, 9, 30)), true);
+        Provision p1 = new Provision(new TermCode("s1", "code1"), Period.of(LocalDate.of(2025, 9, 10), LocalDate.of(2025, 9, 30)), true);
         ConsentProvisions consent = new ConsentProvisions("patient1", null, List.of(p1));
 
         Encounter e1 = createEncounter("patient1", LocalDate.of(2025, 9, 5), LocalDate.of(2025, 9, 15));
@@ -112,7 +112,7 @@ class ConsentAdjusterUnitTest {
 
     @Test
     void testAdjustProvisions_multipleOverlaps_shiftsToEarliest() {
-        Provision p1 = new Provision(new ConsentCode("s1", "code1"), Period.of(LocalDate.of(2025, 9, 10), LocalDate.of(2025, 9, 30)), true);
+        Provision p1 = new Provision(new TermCode("s1", "code1"), Period.of(LocalDate.of(2025, 9, 10), LocalDate.of(2025, 9, 30)), true);
         ConsentProvisions consent = new ConsentProvisions("patient1", null, List.of(p1));
 
         Encounter e1 = createEncounter("patient1", LocalDate.of(2025, 9, 8), LocalDate.of(2025, 9, 12));
@@ -132,8 +132,8 @@ class ConsentAdjusterUnitTest {
     void testFetchAndAdjust_withMockedDataStore() {
         PatientBatch batch = new PatientBatch(List.of("patient1", "patient2"));
 
-        Provision p1 = new Provision(new ConsentCode("s1", "code1"), Period.of(LocalDate.of(2025, 9, 10), LocalDate.of(2025, 9, 30)), true);
-        Provision p2 = new Provision(new ConsentCode("s1", "code2"), Period.of(LocalDate.of(2025, 10, 1), LocalDate.of(2025, 10, 31)), true);
+        Provision p1 = new Provision(new TermCode("s1", "code1"), Period.of(LocalDate.of(2025, 9, 10), LocalDate.of(2025, 9, 30)), true);
+        Provision p2 = new Provision(new TermCode("s1", "code2"), Period.of(LocalDate.of(2025, 10, 1), LocalDate.of(2025, 10, 31)), true);
         ConsentProvisions consent1 = new ConsentProvisions("patient1", null, List.of(p1));
         ConsentProvisions consent2 = new ConsentProvisions("patient2", null, List.of(p2));
 

--- a/src/test/java/de/medizininformatikinitiative/torch/consent/ConsentCalculatorTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/consent/ConsentCalculatorTest.java
@@ -1,7 +1,11 @@
 package de.medizininformatikinitiative.torch.consent;
 
 import de.medizininformatikinitiative.torch.exceptions.ConsentViolatedException;
-import de.medizininformatikinitiative.torch.model.consent.*;
+import de.medizininformatikinitiative.torch.model.consent.ConsentProvisions;
+import de.medizininformatikinitiative.torch.model.consent.NonContinuousPeriod;
+import de.medizininformatikinitiative.torch.model.consent.Period;
+import de.medizininformatikinitiative.torch.model.consent.Provision;
+import de.medizininformatikinitiative.torch.model.management.TermCode;
 import org.hl7.fhir.r4.model.DateTimeType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -20,9 +24,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @ExtendWith(MockitoExtension.class)
 class ConsentCalculatorTest {
 
-    public static final ConsentCode someCode = new ConsentCode("s1", "someConsentKey");
-    public static final ConsentCode CODE_1 = new ConsentCode("s1", "code1");
-    public static final ConsentCode CODE_2 = new ConsentCode("s1", "code2");
+    public static final TermCode someCode = new TermCode("s1", "someConsentKey");
+    public static final TermCode CODE_1 = new TermCode("s1", "code1");
+    public static final TermCode CODE_2 = new TermCode("s1", "code2");
     private ConsentCalculator calculator;
 
     private static Period p(String start, String end) {
@@ -41,10 +45,10 @@ class ConsentCalculatorTest {
             calculator = new ConsentCalculator();
 
             // Provision has an irrelevant code "otherCode"
-            Provision irrelevant = new Provision(new ConsentCode("s1", "otherCode"), p("2024-01-01", "2024-01-31"), true);
+            Provision irrelevant = new Provision(new TermCode("s1", "otherCode"), p("2024-01-01", "2024-01-31"), true);
             ConsentProvisions cp = new ConsentProvisions("patient1", null, List.of(irrelevant));
 
-            Map<ConsentCode, NonContinuousPeriod> result = calculator.subtractAndMergeByCode(
+            Map<TermCode, NonContinuousPeriod> result = calculator.subtractAndMergeByCode(
                     List.of(cp),
                     Set.of(someCode)
             );
@@ -67,7 +71,7 @@ class ConsentCalculatorTest {
                     List.of(permit, deny)
             );
 
-            Map<ConsentCode, NonContinuousPeriod> result = calculator.subtractAndMergeByCode(
+            Map<TermCode, NonContinuousPeriod> result = calculator.subtractAndMergeByCode(
                     List.of(cp),
                     Set.of(someCode)
             );
@@ -109,7 +113,7 @@ class ConsentCalculatorTest {
                     List.of(permitCode2)
             );
 
-            Map<ConsentCode, NonContinuousPeriod> result = calculator.subtractAndMergeByCode(
+            Map<TermCode, NonContinuousPeriod> result = calculator.subtractAndMergeByCode(
                     List.of(old, newer, cp2),
                     Set.of(CODE_1, CODE_2)
             );
@@ -133,7 +137,7 @@ class ConsentCalculatorTest {
             Provision deny = new Provision(CODE_1, p("2024-03-01", "2024-03-10"), false);
             ConsentProvisions cp = new ConsentProvisions("patient1", null, List.of(deny));
 
-            Map<ConsentCode, NonContinuousPeriod> result = calculator.subtractAndMergeByCode(
+            Map<TermCode, NonContinuousPeriod> result = calculator.subtractAndMergeByCode(
                     List.of(cp),
                     Set.of(CODE_1)
             );
@@ -154,7 +158,7 @@ class ConsentCalculatorTest {
 
         @Test
         void intersectConsent_multipleCodes_overlap() throws ConsentViolatedException {
-            Map<ConsentCode, NonContinuousPeriod> consentsByCode = Map.of(
+            Map<TermCode, NonContinuousPeriod> consentsByCode = Map.of(
                     CODE_1, new NonContinuousPeriod(List.of(p("2024-01-01", "2024-01-10"))),
                     CODE_2, new NonContinuousPeriod(List.of(p("2024-01-05", "2024-01-15")))
             );
@@ -167,7 +171,7 @@ class ConsentCalculatorTest {
 
         @Test
         void intersectConsent_multipleCodes_noOverlap_throws() {
-            Map<ConsentCode, NonContinuousPeriod> consentsByCode = Map.of(
+            Map<TermCode, NonContinuousPeriod> consentsByCode = Map.of(
                     CODE_1, new NonContinuousPeriod(List.of(p("2024-01-01", "2024-01-10"))),
                     CODE_2, new NonContinuousPeriod(List.of(p("2024-01-11", "2024-01-20")))
             );

--- a/src/test/java/de/medizininformatikinitiative/torch/consent/ConsentFetcherIT.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/consent/ConsentFetcherIT.java
@@ -2,8 +2,8 @@ package de.medizininformatikinitiative.torch.consent;
 
 import de.medizininformatikinitiative.torch.Torch;
 import de.medizininformatikinitiative.torch.exceptions.ConsentViolatedException;
-import de.medizininformatikinitiative.torch.model.consent.ConsentCode;
 import de.medizininformatikinitiative.torch.model.management.PatientBatch;
+import de.medizininformatikinitiative.torch.model.management.TermCode;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -53,7 +53,7 @@ class ConsentFetcherIT {
 
     @Test
     void failsOnUnknownPatientBuildingConsent() {
-        var codes = consentCodeMapper.getCombinedCodes(new ConsentCode("fdpg.mii.cds", "yes-yes-yes-yes"));
+        var codes = consentCodeMapper.getCombinedCodes(new TermCode("fdpg.mii.cds", "yes-yes-yes-yes"));
         var result = consentFetcher.fetchConsentInfo(codes, BATCH_UNKNOWN);
 
         StepVerifier.create(result)
@@ -66,7 +66,7 @@ class ConsentFetcherIT {
     @Test
     void successBuildingConsent() {
 
-        var codes = consentCodeMapper.getCombinedCodes(new ConsentCode("fdpg.mii.cds", "yes-yes-yes-yes"));
+        var codes = consentCodeMapper.getCombinedCodes(new TermCode("fdpg.mii.cds", "yes-yes-yes-yes"));
         var result = consentFetcher.fetchConsentInfo(codes, BATCH);
 
         StepVerifier.create(result)

--- a/src/test/java/de/medizininformatikinitiative/torch/consent/ConsentFetcherTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/consent/ConsentFetcherTest.java
@@ -2,8 +2,8 @@ package de.medizininformatikinitiative.torch.consent;
 
 import de.medizininformatikinitiative.torch.exceptions.ConsentViolatedException;
 import de.medizininformatikinitiative.torch.exceptions.PatientIdNotFoundException;
-import de.medizininformatikinitiative.torch.model.consent.ConsentCode;
 import de.medizininformatikinitiative.torch.model.management.PatientBatch;
+import de.medizininformatikinitiative.torch.model.management.TermCode;
 import de.medizininformatikinitiative.torch.service.DataStore;
 import de.medizininformatikinitiative.torch.util.ResourceUtils;
 import org.hl7.fhir.r4.model.Consent;
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class ConsentFetcherTest {
 
-    public static final Set<ConsentCode> CODES = Set.of(new ConsentCode("s1", "c1"));
+    public static final Set<TermCode> CODES = Set.of(new TermCode("s1", "c1"));
     @Mock
     private DataStore dataStore;
 

--- a/src/test/java/de/medizininformatikinitiative/torch/consent/ConsentHandlerIT.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/consent/ConsentHandlerIT.java
@@ -1,9 +1,9 @@
 package de.medizininformatikinitiative.torch.consent;
 
 import de.medizininformatikinitiative.torch.Torch;
-import de.medizininformatikinitiative.torch.model.consent.ConsentCode;
 import de.medizininformatikinitiative.torch.model.consent.PatientBatchWithConsent;
 import de.medizininformatikinitiative.torch.model.management.PatientBatch;
+import de.medizininformatikinitiative.torch.model.management.TermCode;
 import org.hl7.fhir.r4.model.DateTimeType;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Reference;
@@ -66,7 +66,7 @@ class ConsentHandlerIT {
 
     @Test
     void successAfterEncounterUpdatesProvisions() {
-        var resultBatch = consentHandler.fetchAndBuildConsentInfo(Set.of(new ConsentCode("fdpg.mii.cds", "yes-yes-yes-yes")), BATCH);
+        var resultBatch = consentHandler.fetchAndBuildConsentInfo(Set.of(new TermCode("fdpg.mii.cds", "yes-yes-yes-yes")), BATCH);
 
         StepVerifier.create(resultBatch)
                 .assertNext(batch -> {

--- a/src/test/java/de/medizininformatikinitiative/torch/consent/ConsentHandlerTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/consent/ConsentHandlerTest.java
@@ -1,8 +1,8 @@
 package de.medizininformatikinitiative.torch.consent;
 
 import de.medizininformatikinitiative.torch.exceptions.ConsentViolatedException;
-import de.medizininformatikinitiative.torch.model.consent.ConsentCode;
 import de.medizininformatikinitiative.torch.model.management.PatientBatch;
+import de.medizininformatikinitiative.torch.model.management.TermCode;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -23,7 +23,7 @@ public class ConsentHandlerTest {
     public static final String UNKNOWN_PATIENT_ID = "Unknown";
     public static final PatientBatch BATCH = PatientBatch.of(PATIENT_ID);
     public static final PatientBatch BATCH_UNKNOWN = PatientBatch.of(UNKNOWN_PATIENT_ID);
-    public static final Set<ConsentCode> CODES = Set.of(new ConsentCode("sys", "code1"));
+    public static final Set<TermCode> CODES = Set.of(new TermCode("sys", "code1"));
 
     @Mock
     ConsentFetcher consentFetcher;

--- a/src/test/java/de/medizininformatikinitiative/torch/consent/ProvisionExtractorTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/consent/ProvisionExtractorTest.java
@@ -2,10 +2,10 @@ package de.medizininformatikinitiative.torch.consent;
 
 import de.medizininformatikinitiative.torch.exceptions.ConsentViolatedException;
 import de.medizininformatikinitiative.torch.exceptions.PatientIdNotFoundException;
-import de.medizininformatikinitiative.torch.model.consent.ConsentCode;
 import de.medizininformatikinitiative.torch.model.consent.ConsentProvisions;
 import de.medizininformatikinitiative.torch.model.consent.Period;
 import de.medizininformatikinitiative.torch.model.consent.Provision;
+import de.medizininformatikinitiative.torch.model.management.TermCode;
 import org.hl7.fhir.r4.model.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,9 +19,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ProvisionExtractorTest {
 
-    public static final ConsentCode CODE_1 = new ConsentCode("sys", "code1");
-    public static final ConsentCode CODE_2 = new ConsentCode("sys", "code2");
-    public static final ConsentCode CODE_3 = new ConsentCode("sys", "code3");
+    public static final TermCode CODE_1 = new TermCode("sys", "code1");
+    public static final TermCode CODE_2 = new TermCode("sys", "code2");
+    public static final TermCode CODE_3 = new TermCode("sys", "code3");
     private ProvisionExtractor extractor;
 
     @BeforeEach
@@ -248,7 +248,7 @@ class ProvisionExtractorTest {
 
         consent.setProvision(parentProvision);
 
-        Set<ConsentCode> requiredCodes = Set.of(CODE_1, CODE_2, CODE_3);
+        Set<TermCode> requiredCodes = Set.of(CODE_1, CODE_2, CODE_3);
 
         ConsentProvisions result = extractor.extractProvisionsPeriodByCode(consent, requiredCodes);
 
@@ -304,7 +304,7 @@ class ProvisionExtractorTest {
         consent.setProvision(new Consent.ProvisionComponent());
 
         assertThatThrownBy(() ->
-                extractor.extractProvisionsPeriodByCode(consent, Set.of(new ConsentCode("sys", "anyCode")))
+                extractor.extractProvisionsPeriodByCode(consent, Set.of(new TermCode("sys", "anyCode")))
         ).isInstanceOf(ConsentViolatedException.class)
                 .hasMessageContaining("consent-null-date has no valid consent date");
     }

--- a/src/test/java/de/medizininformatikinitiative/torch/model/consent/ConsentProvisionsTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/model/consent/ConsentProvisionsTest.java
@@ -1,5 +1,6 @@
 package de.medizininformatikinitiative.torch.model.consent;
 
+import de.medizininformatikinitiative.torch.model.management.TermCode;
 import org.hl7.fhir.r4.model.Encounter;
 import org.junit.jupiter.api.Test;
 
@@ -12,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ConsentProvisionsTest {
 
-    public static final ConsentCode CODE = new ConsentCode("sys1", "code1");
+    public static final TermCode CODE = new TermCode("sys1", "code1");
 
     // Helper to create an Encounter with a specific period
     private Encounter createEncounter(LocalDate start, LocalDate end) {

--- a/src/test/java/de/medizininformatikinitiative/torch/model/consent/TermCodeTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/model/consent/TermCodeTest.java
@@ -1,15 +1,16 @@
 package de.medizininformatikinitiative.torch.model.consent;
 
+import de.medizininformatikinitiative.torch.model.management.TermCode;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
-class ConsentCodeTest {
+class TermCodeTest {
 
     @Test
     void validConsentCodeShouldBeCreated() {
-        ConsentCode consentCode = new ConsentCode("systemA", "code123");
+        TermCode consentCode = new TermCode("systemA", "code123");
 
         assertThat(consentCode.system()).isEqualTo("systemA");
         assertThat(consentCode.code()).isEqualTo("code123");
@@ -17,28 +18,28 @@ class ConsentCodeTest {
 
     @Test
     void nullSystemShouldThrowException() {
-        assertThatThrownBy(() -> new ConsentCode(null, "code123"))
+        assertThatThrownBy(() -> new TermCode(null, "code123"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("system must not be null or blank");
     }
 
     @Test
     void blankSystemShouldThrowException() {
-        assertThatThrownBy(() -> new ConsentCode("   ", "code123"))
+        assertThatThrownBy(() -> new TermCode("   ", "code123"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("system must not be null or blank");
     }
 
     @Test
     void nullCodeShouldThrowException() {
-        assertThatThrownBy(() -> new ConsentCode("systemA", null))
+        assertThatThrownBy(() -> new TermCode("systemA", null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("code must not be null or blank");
     }
 
     @Test
     void blankCodeShouldThrowException() {
-        assertThatThrownBy(() -> new ConsentCode("systemA", " "))
+        assertThatThrownBy(() -> new TermCode("systemA", " "))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("code must not be null or blank");
     }

--- a/src/test/java/de/medizininformatikinitiative/torch/model/crtdl/annotated/AnnotatedCrtdlTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/model/crtdl/annotated/AnnotatedCrtdlTest.java
@@ -2,7 +2,7 @@ package de.medizininformatikinitiative.torch.model.crtdl.annotated;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import de.medizininformatikinitiative.torch.model.consent.ConsentCode;
+import de.medizininformatikinitiative.torch.model.management.TermCode;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -53,13 +53,13 @@ class AnnotatedCrtdlTest {
         JsonNode cohortDefinition = mapper.readTree(json);
         AnnotatedCrtdl crtdl = new AnnotatedCrtdl(cohortDefinition, emptyDataExtraction());
 
-        Optional<Set<ConsentCode>> codes = crtdl.consentKey();
+        Optional<Set<TermCode>> codes = crtdl.consentKey();
 
         assertThat(codes).isPresent();
         assertThat(codes.get()).containsExactlyInAnyOrder(
-                new ConsentCode("s1", "A1")
-                , new ConsentCode("s1", "A2")
-                , new ConsentCode("s1", "B1"));
+                new TermCode("s1", "A1")
+                , new TermCode("s1", "A2")
+                , new TermCode("s1", "B1"));
     }
 
     @Test
@@ -86,11 +86,11 @@ class AnnotatedCrtdlTest {
         JsonNode cohortDefinition = mapper.readTree(json);
         AnnotatedCrtdl crtdl = new AnnotatedCrtdl(cohortDefinition, emptyDataExtraction());
 
-        Optional<Set<ConsentCode>> codes = crtdl.consentKey();
+        Optional<Set<TermCode>> codes = crtdl.consentKey();
 
         // Only the array element contributes (X2)
         assertThat(codes).isPresent();
-        assertThat(codes.get()).containsExactly(new ConsentCode("s1", "X2"));
+        assertThat(codes.get()).containsExactly(new TermCode("s1", "X2"));
     }
 
     @Test
@@ -118,11 +118,11 @@ class AnnotatedCrtdlTest {
         JsonNode cohortDefinition = mapper.readTree(json);
         AnnotatedCrtdl crtdl = new AnnotatedCrtdl(cohortDefinition, emptyDataExtraction());
 
-        Optional<Set<ConsentCode>> codes = crtdl.consentKey();
+        Optional<Set<TermCode>> codes = crtdl.consentKey();
 
         // Only the last one should remain
         assertThat(codes).isPresent();
-        assertThat(codes.get()).containsExactly(new ConsentCode("s1", "VALID"));
+        assertThat(codes.get()).containsExactly(new TermCode("s1", "VALID"));
     }
 
     @Test
@@ -153,10 +153,10 @@ class AnnotatedCrtdlTest {
         JsonNode cohortDefinition = mapper.readTree(json);
         AnnotatedCrtdl crtdl = new AnnotatedCrtdl(cohortDefinition, emptyDataExtraction());
 
-        Optional<Set<ConsentCode>> codes = crtdl.consentKey();
+        Optional<Set<TermCode>> codes = crtdl.consentKey();
 
         assertThat(codes).isPresent();
-        assertThat(codes.get()).containsExactly(new ConsentCode("s1", "TOP1"));
+        assertThat(codes.get()).containsExactly(new TermCode("s1", "TOP1"));
     }
 
     @Test
@@ -165,7 +165,7 @@ class AnnotatedCrtdlTest {
         JsonNode cohortDefinition = mapper.readTree(json);
         AnnotatedCrtdl crtdl = new AnnotatedCrtdl(cohortDefinition, emptyDataExtraction());
 
-        Optional<Set<ConsentCode>> codes = crtdl.consentKey();
+        Optional<Set<TermCode>> codes = crtdl.consentKey();
 
         assertThat(codes).isEmpty();
     }
@@ -188,7 +188,7 @@ class AnnotatedCrtdlTest {
         JsonNode cohortDefinition = mapper.readTree(json);
         AnnotatedCrtdl crtdl = new AnnotatedCrtdl(cohortDefinition, emptyDataExtraction());
 
-        Optional<Set<ConsentCode>> codes = crtdl.consentKey();
+        Optional<Set<TermCode>> codes = crtdl.consentKey();
 
         assertThat(codes).isEmpty();
     }

--- a/src/test/java/de/medizininformatikinitiative/torch/util/ProvisionExtractorIT.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/util/ProvisionExtractorIT.java
@@ -5,10 +5,10 @@ import de.medizininformatikinitiative.torch.consent.ConsentCodeMapper;
 import de.medizininformatikinitiative.torch.consent.ProvisionExtractor;
 import de.medizininformatikinitiative.torch.exceptions.ConsentViolatedException;
 import de.medizininformatikinitiative.torch.exceptions.PatientIdNotFoundException;
-import de.medizininformatikinitiative.torch.model.consent.ConsentCode;
 import de.medizininformatikinitiative.torch.model.consent.ConsentProvisions;
 import de.medizininformatikinitiative.torch.model.consent.Period;
 import de.medizininformatikinitiative.torch.model.consent.Provision;
+import de.medizininformatikinitiative.torch.model.management.TermCode;
 import de.medizininformatikinitiative.torch.setup.IntegrationTestSetup;
 import org.hl7.fhir.r4.model.*;
 import org.junit.jupiter.api.Test;
@@ -42,7 +42,7 @@ class ProvisionExtractorIT {
     @Test
     void irrelevantCodesSkipped() throws ConsentViolatedException, PatientIdNotFoundException {
         ProvisionExtractor processor = new ProvisionExtractor();
-        Set<ConsentCode> expectedCodes = consentCodeMapper.getCombinedCodes(new ConsentCode("fdpg.mii.cds", "yes-yes-yes-yes"));
+        Set<TermCode> expectedCodes = consentCodeMapper.getCombinedCodes(new TermCode("fdpg.mii.cds", "yes-yes-yes-yes"));
         Consent consent = new Consent();
         consent.setPatient(new Reference("Patient/123"));
         consent.setDateTime(new DateTimeType("2023-01-01").getValue());
@@ -63,7 +63,7 @@ class ProvisionExtractorIT {
     @Test
     void deniesExtracted() throws ConsentViolatedException, PatientIdNotFoundException {
         ProvisionExtractor processor = new ProvisionExtractor();
-        Set<ConsentCode> expectedCodes = consentCodeMapper.getCombinedCodes(new ConsentCode("fdpg.mii.cds", "yes-yes-yes-yes"));
+        Set<TermCode> expectedCodes = consentCodeMapper.getCombinedCodes(new TermCode("fdpg.mii.cds", "yes-yes-yes-yes"));
         Consent consent = new Consent();
         consent.setPatient(new Reference("Patient/123"));
         consent.setDateTime(new DateTimeType("2023-01-01").getValue());
@@ -90,7 +90,7 @@ class ProvisionExtractorIT {
     @ValueSource(strings = {"VHF006_Consent.json"})
     void extractsPermits(String resource) throws IOException, ConsentViolatedException, PatientIdNotFoundException {
         ProvisionExtractor processor = new ProvisionExtractor();
-        Set<ConsentCode> consentCodes = consentCodeMapper.getCombinedCodes(new ConsentCode("fdpg.mii.cds", "yes-yes-yes-yes"));
+        Set<TermCode> consentCodes = consentCodeMapper.getCombinedCodes(new TermCode("fdpg.mii.cds", "yes-yes-yes-yes"));
         Consent consent = (Consent) integrationTestSetup.readResource("src/test/resources/InputResources/Consent/" + resource);
 
         ConsentProvisions consentProvisions = processor.extractProvisionsPeriodByCode(consent, consentCodes);
@@ -98,7 +98,7 @@ class ProvisionExtractorIT {
 
         assertThat(provisions.isEmpty()).isFalse();
 
-        Set<ConsentCode> actualCodes = provisions.stream()
+        Set<TermCode> actualCodes = provisions.stream()
                 .map(Provision::code)
                 .collect(Collectors.toSet());
         assertThat(actualCodes).isEqualTo(consentCodes);
@@ -113,7 +113,7 @@ class ProvisionExtractorIT {
     @Test
     void throwsConsentViolatedException_whenConsentHasNoDateTime() {
         ProvisionExtractor processor = new ProvisionExtractor();
-        Set<ConsentCode> expectedCodes = consentCodeMapper.getCombinedCodes(new ConsentCode("fdpg.mii.cds", "yes-yes-yes-yes"));
+        Set<TermCode> expectedCodes = consentCodeMapper.getCombinedCodes(new TermCode("fdpg.mii.cds", "yes-yes-yes-yes"));
 
         Consent consent = new Consent();
         consent.setId("consent-no-date");
@@ -129,7 +129,7 @@ class ProvisionExtractorIT {
     @Test
     void throwsConsentViolatedException_whenConsentDateTimeIsEmpty() {
         ProvisionExtractor processor = new ProvisionExtractor();
-        Set<ConsentCode> expectedCodes = consentCodeMapper.getCombinedCodes(new ConsentCode("fdpg.mii.cds", "yes-yes-yes-yes"));
+        Set<TermCode> expectedCodes = consentCodeMapper.getCombinedCodes(new TermCode("fdpg.mii.cds", "yes-yes-yes-yes"));
 
         Consent consent = new Consent();
         consent.setId("consent-empty-date");
@@ -145,7 +145,7 @@ class ProvisionExtractorIT {
     @Test
     void skipsProvisionsWithoutStartOrEnd() throws ConsentViolatedException, PatientIdNotFoundException {
         ProvisionExtractor processor = new ProvisionExtractor();
-        Set<ConsentCode> expectedCodes = consentCodeMapper.getCombinedCodes(new ConsentCode("fdpg.mii.cds", "yes-yes-yes-yes"));
+        Set<TermCode> expectedCodes = consentCodeMapper.getCombinedCodes(new TermCode("fdpg.mii.cds", "yes-yes-yes-yes"));
 
         Consent consent = new Consent();
         consent.setPatient(new Reference("Patient/123"));

--- a/src/test/java/de/medizininformatikinitiative/torch/util/TermCodeMapperIT.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/util/TermCodeMapperIT.java
@@ -2,7 +2,7 @@ package de.medizininformatikinitiative.torch.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.medizininformatikinitiative.torch.consent.ConsentCodeMapper;
-import de.medizininformatikinitiative.torch.model.consent.ConsentCode;
+import de.medizininformatikinitiative.torch.model.management.TermCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -11,10 +11,10 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ConsentCodeMapperIT {
+class TermCodeMapperIT {
 
-    public static final ConsentCode MIIConsentCode = new ConsentCode("urn:oid:2.16.840.1.113883.3.1937.777.24.5.3", "2.16.840.1.113883.3.1937.777.24.5.3.8");
-    public static final ConsentCode CODE1 = new ConsentCode("s1", "code1");
+    public static final TermCode MIIConsentCode = new TermCode("urn:oid:2.16.840.1.113883.3.1937.777.24.5.3", "2.16.840.1.113883.3.1937.777.24.5.3.8");
+    public static final TermCode CODE1 = new TermCode("s1", "code1");
     private ConsentCodeMapper consentCodeMapper;
 
     @BeforeEach
@@ -26,8 +26,8 @@ class ConsentCodeMapperIT {
 
     @Test
     void combinedCodesValidCode() {
-        Set<ConsentCode> relevantCodes = consentCodeMapper.getCombinedCodes(
-                new ConsentCode("fdpg.mii.cds", "yes-yes-yes-yes")
+        Set<TermCode> relevantCodes = consentCodeMapper.getCombinedCodes(
+                new TermCode("fdpg.mii.cds", "yes-yes-yes-yes")
         );
 
         assertThat(relevantCodes)
@@ -38,8 +38,8 @@ class ConsentCodeMapperIT {
 
     @Test
     void combinedCodesInvalidCode() {
-        Set<ConsentCode> relevantCodes = consentCodeMapper.getCombinedCodes(
-                new ConsentCode("fdpg.mii.cds", "invalid-key")
+        Set<TermCode> relevantCodes = consentCodeMapper.getCombinedCodes(
+                new TermCode("fdpg.mii.cds", "invalid-key")
         );
 
         assertThat(relevantCodes)
@@ -49,8 +49,8 @@ class ConsentCodeMapperIT {
 
     @Test
     void combinedCodesUnknownSystem() {
-        Set<ConsentCode> relevantCodes = consentCodeMapper.getCombinedCodes(
-                new ConsentCode("unknown_System", "invalid-key")
+        Set<TermCode> relevantCodes = consentCodeMapper.getCombinedCodes(
+                new TermCode("unknown_System", "invalid-key")
         );
 
         assertThat(relevantCodes)
@@ -60,8 +60,8 @@ class ConsentCodeMapperIT {
 
     @Test
     void expandWithCombinedCodes() {
-        Set<ConsentCode> relevantCodes = consentCodeMapper.addCombinedCodes(
-                Set.of(CODE1, new ConsentCode("fdpg.mii.cds", "yes-yes-yes-yes"))
+        Set<TermCode> relevantCodes = consentCodeMapper.addCombinedCodes(
+                Set.of(CODE1, new TermCode("fdpg.mii.cds", "yes-yes-yes-yes"))
         );
 
         assertThat(relevantCodes)

--- a/src/test/java/de/medizininformatikinitiative/torch/util/TermCodeMapperTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/util/TermCodeMapperTest.java
@@ -3,7 +3,7 @@ package de.medizininformatikinitiative.torch.util;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.medizininformatikinitiative.torch.consent.ConsentCodeMapper;
-import de.medizininformatikinitiative.torch.model.consent.ConsentCode;
+import de.medizininformatikinitiative.torch.model.management.TermCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-class ConsentCodeMapperTest {
+class TermCodeMapperTest {
 
     private ObjectMapper objectMapperMock;
     private ConsentCodeMapper consentCodeMapper;
@@ -64,8 +64,8 @@ class ConsentCodeMapperTest {
     @Test
     @DisplayName("Test getRelevantCodes returns expected codes for valid key")
     void testGetRelevantCodes() {
-        Set<ConsentCode> relevantCodes = consentCodeMapper.getCombinedCodes(new ConsentCode("fdpg.mii.cds", "CONSENT_KEY_1"));
-        Set<ConsentCode> expectedCodes = Set.of(new ConsentCode("testSystem", "CODE_1"), new ConsentCode("testSystem", "CODE_2"));
+        Set<TermCode> relevantCodes = consentCodeMapper.getCombinedCodes(new TermCode("fdpg.mii.cds", "CONSENT_KEY_1"));
+        Set<TermCode> expectedCodes = Set.of(new TermCode("testSystem", "CODE_1"), new TermCode("testSystem", "CODE_2"));
 
         assertEquals(expectedCodes, relevantCodes);
     }
@@ -74,7 +74,7 @@ class ConsentCodeMapperTest {
     @Test
     @DisplayName("Test getRelevantCodes returns isEmpty set for non-existent key")
     void testGetRelevantCodesForNonExistentKey() {
-        Set<ConsentCode> relevantCodes = consentCodeMapper.getCombinedCodes(new ConsentCode("fdpg.mii.cds", "NON_EXISTENT_KEY"));
+        Set<TermCode> relevantCodes = consentCodeMapper.getCombinedCodes(new TermCode("fdpg.mii.cds", "NON_EXISTENT_KEY"));
 
         assertTrue(relevantCodes.isEmpty(), "Expected an isEmpty set for a non-existent key");
     }
@@ -101,6 +101,6 @@ class ConsentCodeMapperTest {
         // Reinitialize with the mocked ObjectMapper
         consentCodeMapper = new ConsentCodeMapper("/dummy/path", objectMapperMock);
 
-        assertTrue(consentCodeMapper.getCombinedCodes(new ConsentCode("fdpg.mii.cds", "ANY_KEY")).isEmpty(), "Expected isEmpty set for invalid JSON structure");
+        assertTrue(consentCodeMapper.getCombinedCodes(new TermCode("fdpg.mii.cds", "ANY_KEY")).isEmpty(), "Expected isEmpty set for invalid JSON structure");
     }
 }


### PR DESCRIPTION
Refactoring ConsentCode to TermCode for wider generic reuse of that class to avoid doubling of code classes that just need the fields system and code. 