### PR TITLE
Set required recorded field on Provenance resource

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/torch/model/management/ResourceBundle.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/model/management/ResourceBundle.java
@@ -265,6 +265,7 @@ public record ResourceBundle(
     private static Provenance createProvenance(String extractionId, String groupId, List<ResourceGroup> groupResources) {
         Provenance provenance = new Provenance();
         provenance.setId(PROVENANCE_PREFIX + groupId);
+        provenance.setRecorded(new Date());
 
         // Add all resources under the same group as targets
         groupResources.forEach(rg ->

--- a/src/test/java/de/medizininformatikinitiative/torch/ReferenceResolveBlackBoxIT.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/ReferenceResolveBlackBoxIT.java
@@ -109,7 +109,7 @@ class ReferenceResolveBlackBoxIT {
                 .allSatisfy(
 
                         r -> assertThat(r).extractTopElementNames()
-                                .containsExactlyInAnyOrder("resourceType", "id", "target", "occurredPeriod", "agent", "entity")));
+                                .containsExactlyInAnyOrder("resourceType", "id", "target", "recorded", "occurredPeriod", "agent", "entity")));
 
         // all Encounter in all patient bundles must have the given top fields and have at least one reference in diagnosis.condition
         assertThat(patientBundles).allSatisfy(b -> assertThat(b).extractResourcesByType(ResourceType.Encounter)


### PR DESCRIPTION
The FHIR R4 Provenance resource requires the recorded field (1..1 cardinality). This was missing, making the generated Provenance resources technically invalid.