### PR TITLE
Fix CVE-2026-34361: pin org.hl7.fhir.validation to 6.9.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,8 @@
         </dependency>
 
         <!-- Overriding org.hl7.fhir.core modules that come from hapi-fhir-structures-r4/validation
-             and are affected by CVE-2026-33180 (information disclosure via HTTP redirects) -->
+             and are affected by CVE-2026-33180 (information disclosure via HTTP redirects)
+             and CVE-2026-34361 (SSRF + credential leak via /loadIG) -->
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>org.hl7.fhir.r4</artifactId>
@@ -104,6 +105,11 @@
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>org.hl7.fhir.utilities</artifactId>
+            <version>${hapi-fhir-core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ca.uhn.hapi.fhir</groupId>
+            <artifactId>org.hl7.fhir.validation</artifactId>
             <version>${hapi-fhir-core.version}</version>
         </dependency>
 


### PR DESCRIPTION
## Summary

- Pins `ca.uhn.hapi.fhir:org.hl7.fhir.validation` to `${hapi-fhir-core.version}` (6.9.7) in the existing override block
- Fixes CVE-2026-34361 (Critical): SSRF via `/loadIG` + credential leak via `startsWith()` bypass
- Adds `org.hl7.fhir.validation` to the comment listing the CVEs addressed by the override block

Closes #882

## Root cause

`hapi-fhir-validation:8.8.1` pulls `org.hl7.fhir.validation` in transitively at 6.7.9. The project already overrides `org.hl7.fhir.r4`, `org.hl7.fhir.r5`, and `org.hl7.fhir.utilities` to 6.9.7 for CVE-2026-33180, but `org.hl7.fhir.validation` was not included. All other `org.hl7.fhir.*` transitive artifacts already resolve at 6.9.7.

## Test plan

- [ ] `mvn dependency:tree | grep hl7.fhir.validation` shows `6.9.7`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)