### PR TITLE
Record exception as issue in onBatchError and onCohortError

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/torch/jobhandling/Job.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/jobhandling/Job.java
@@ -215,7 +215,11 @@ public record Job(
         boolean retryable = RetryabilityUtil.isRetryable(e);
         WorkUnitState out = cohortState.onFailure(retryable);
         Job updated = withCohortState(out)
-                .withIssuesAdded(issues);
+                .withIssuesAdded(merge(issues, List.of(Issue.fromException(
+                        retryable ? Severity.WARNING : Severity.ERROR,
+                        "Cohort query failed: " + e.getMessage(),
+                        e
+                ))));
         if (!retryable) return updated.withStatus(JobStatus.FAILED);
         return updated.withStatus(JobStatus.TEMP_FAILED);
     }
@@ -240,7 +244,12 @@ public record Job(
         if (status != JobStatus.RUNNING_PROCESS_BATCH) {
             return this;
         }
-        Job updated = withIssuesAdded(issues);
+        boolean retryable = RetryabilityUtil.isRetryable(e);
+        Job updated = withIssuesAdded(merge(issues, List.of(Issue.fromException(
+                retryable ? Severity.WARNING : Severity.ERROR,
+                "Batch " + batchId + " failed: " + e.getMessage(),
+                e
+        ))));
 
         BatchState bs = updated.batches().get(batchId);
         if (bs == null) {
@@ -253,7 +262,6 @@ public record Job(
                     .withStatus(JobStatus.FAILED);
         }
 
-        boolean retryable = RetryabilityUtil.isRetryable(e);
         BatchState out = bs.onFailure(retryable);
 
         Job withBatch = updated.withBatchState(out);


### PR DESCRIPTION
Fixes missing error details in OperationOutcome when a batch or cohort query fails. Both `onBatchError` and `onCohortError` were not calling `Issue.fromException()`, so `job.issues()` was empty and the returned OperationOutcome contained only the informational summary — no actual error diagnostics.