### PR TITLE
Record exception as issue in onBatchError and onCohortError

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/torch/jobhandling/Job.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/jobhandling/Job.java
@@ -215,7 +215,11 @@ public record Job(
         boolean retryable = RetryabilityUtil.isRetryable(e);
         WorkUnitState out = cohortState.onFailure(retryable);
         Job updated = withCohortState(out)
-                .withIssuesAdded(issues);
+                .withIssuesAdded(merge(issues, List.of(Issue.fromException(
+                        retryable ? Severity.WARNING : Severity.ERROR,
+                        "Cohort query failed: " + e.getMessage(),
+                        e
+                ))));
         if (!retryable) return updated.withStatus(JobStatus.FAILED);
         return updated.withStatus(JobStatus.TEMP_FAILED);
     }
@@ -240,7 +244,12 @@ public record Job(
         if (status != JobStatus.RUNNING_PROCESS_BATCH) {
             return this;
         }
-        Job updated = withIssuesAdded(issues);
+        boolean retryable = RetryabilityUtil.isRetryable(e);
+        Job updated = withIssuesAdded(merge(issues, List.of(Issue.fromException(
+                retryable ? Severity.WARNING : Severity.ERROR,
+                "Batch " + batchId + " failed: " + e.getMessage(),
+                e
+        ))));
 
         BatchState bs = updated.batches().get(batchId);
         if (bs == null) {
@@ -253,7 +262,6 @@ public record Job(
                     .withStatus(JobStatus.FAILED);
         }
 
-        boolean retryable = RetryabilityUtil.isRetryable(e);
         BatchState out = bs.onFailure(retryable);
 
         Job withBatch = updated.withBatchState(out);

--- a/src/test/java/de/medizininformatikinitiative/torch/jobhandling/JobTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/jobhandling/JobTest.java
@@ -558,6 +558,22 @@ public class JobTest {
             assertThat(updated.status()).isEqualTo(JobStatus.TEMP_FAILED);
             assertThat(updated.cohortState().status()).isEqualTo(WorkUnitStatus.TEMP_FAILED);
             assertThat(updated.issues()).containsAll(sampleIssues);
+            assertThat(updated.issues()).anyMatch(i ->
+                    i.severity() == Severity.WARNING && i.msg().contains("Cohort query failed: Retryable"));
+        }
+
+        @Test
+        void onCohortError_nonRetryable_failsWithErrorIssue() {
+            Job j = Job.init(UUID.randomUUID(), TestUtils.emptyJobParams())
+                    .withStatus(JobStatus.RUNNING_GET_COHORT)
+                    .withCohortState(WorkUnitState.startNow());
+
+            Job updated = j.onCohortError(new RuntimeException("Non-retryable"), List.of());
+
+            assertThat(updated.status()).isEqualTo(JobStatus.FAILED);
+            assertThat(updated.cohortState().status()).isEqualTo(WorkUnitStatus.FAILED);
+            assertThat(updated.issues()).anyMatch(i ->
+                    i.severity() == Severity.ERROR && i.msg().contains("Cohort query failed: Non-retryable"));
         }
 
         @Test
@@ -587,6 +603,24 @@ public class JobTest {
             assertThat(updated.status()).isEqualTo(JobStatus.TEMP_FAILED);
             assertThat(updated.batches().get(b1).status()).isEqualTo(WorkUnitStatus.TEMP_FAILED);
             assertThat(updated.issues()).containsAll(sampleIssues);
+            assertThat(updated.issues()).anyMatch(i ->
+                    i.severity() == Severity.WARNING && i.msg().contains("Batch " + b1 + " failed: Retryable"));
+        }
+
+        @Test
+        void onBatchError_nonRetryable_failsWithErrorIssue() {
+            UUID b1 = UUID.randomUUID();
+
+            Job j = Job.init(UUID.randomUUID(), TestUtils.emptyJobParams())
+                    .withStatus(JobStatus.RUNNING_PROCESS_BATCH)
+                    .withBatchState(new BatchState(b1, WorkUnitState.startNow()));
+
+            Job updated = j.onBatchError(b1, new RuntimeException("Non-retryable"), List.of());
+
+            assertThat(updated.status()).isEqualTo(JobStatus.FAILED);
+            assertThat(updated.batches().get(b1).status()).isEqualTo(WorkUnitStatus.FAILED);
+            assertThat(updated.issues()).anyMatch(i ->
+                    i.severity() == Severity.ERROR && i.msg().contains("Batch " + b1 + " failed: Non-retryable"));
         }
 
         @Test


### PR DESCRIPTION
Closes #935

`onBatchError` and `onCohortError` were not calling `Issue.fromException()`, so `job.issues()` was always empty on batch/cohort failures. `OperationOutcomeCreator.fromJob()` then had nothing to iterate and only emitted the generic informational summary — no actual error diagnostics were visible to the caller.

Applied the same `Issue.fromException()` pattern that `onCoreError` already used.