### PR TITLE
Cover missing branch in getMethodWithOneParam to fix Codecov indirect change

### DIFF
--- a/src/test/java/de/medizininformatikinitiative/torch/util/ResourceUtilsTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/util/ResourceUtilsTest.java
@@ -25,7 +25,7 @@ class ResourceUtilsTest {
 
         static class MultiOverload {
             public void doSomething() {}
-            public void doSomething(String ignored) {}
+            public void doSomething(String s) { s.hashCode(); }
         }
 
         @Test

--- a/src/test/java/de/medizininformatikinitiative/torch/util/ResourceUtilsTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/util/ResourceUtilsTest.java
@@ -23,11 +23,22 @@ class ResourceUtilsTest {
     @Nested
     class GetMethodWithOneParam {
 
+        static class MultiOverload {
+            public void doSomething() {}
+            public void doSomething(String ignored) {}
+        }
+
         @Test
         void findsMethodByName() throws NoSuchMethodException {
             Patient patient = new Patient();
             Method method = ResourceUtils.getMethodWithOneParam(patient, "setId");
             assertThat(method.getName()).isEqualTo("setId");
+            assertThat(method.getParameterCount()).isEqualTo(1);
+        }
+
+        @Test
+        void skipsOverloadsWithWrongParamCount() throws NoSuchMethodException {
+            Method method = ResourceUtils.getMethodWithOneParam(new MultiOverload(), "doSomething");
             assertThat(method.getParameterCount()).isEqualTo(1);
         }
 


### PR DESCRIPTION
Closes #949

## Summary
- Adds a `skipsOverloadsWithWrongParamCount` test using a local inner class with two `doSomething` overloads (0-param and 1-param)
- This forces the loop in `getMethodWithOneParam` to exercise the branch where the name matches but `getParameterCount() != 1`
- Coverage is now deterministic regardless of HAPI FHIR version or JVM method ordering

## Test plan
- [ ] `ResourceUtilsTest` passes locally