### PR TITLE
Fix intermittent timing failure in pause-resume-test.sh

### DIFF
--- a/.github/workflows/task-tests/pause-resume-test.sh
+++ b/.github/workflows/task-tests/pause-resume-test.sh
@@ -40,7 +40,18 @@ EXPORT_ID=$(grep "TORCH_EXPORT_ID=" "$LOG" | cut -d= -f2 | xargs)
 
 echo "✅ Export ID: $EXPORT_ID"
 
-sleep 3
+echo "⏳ Waiting for job to be in progress (202)..."
+in_progress=false
+for _ in $(seq 1 60); do
+  code="$(status_code "$EXPORT_ID")"
+  if [[ "$code" == "202" ]]; then
+    in_progress=true
+    break
+  fi
+  [[ "$code" == "200" ]] && fail "Job completed before we could pause it — workload may be too small for this test"
+  sleep 1
+done
+[[ "$in_progress" == "true" ]] || fail "Job never reached in-progress within 60s (last status: $code)"
 
 echo "⏸️ Pause..."
 curl -sf -X POST \


### PR DESCRIPTION
## Summary
- Replaces `sleep 3` with a polling loop that waits for HTTP 202 (in-progress) before pausing
- Handles slow CI (job not yet started) and fast CI (job completes before pause)
- Fails with a clear diagnostic message if the job completes before the pause can land

## Test plan
- [ ] Trigger the task-api-test workflow and confirm pause-resume-test.sh passes consistently

Closes #951