### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,30 @@
+cff-version: 1.2.0
+title: "TORCH - Transfer Of Resources in Clinical Healthcare"
+message: "If you use this software, please cite it as below."
+type: software
+authors:
+  - family-names: Triefenbach
+    given-names: Lucas
+    orcid: "https://orcid.org/0000-0003-4124-1989"
+  - family-names: Gründner
+    given-names: Julian
+    orcid: "https://orcid.org/0000-0001-7204-5329"
+  - family-names: Kiel
+    given-names: Alexander
+    orcid: "https://orcid.org/0000-0003-0461-8185"
+  - family-names: Schaffer
+    given-names: Bastian
+    orcid: "https://orcid.org/0009-0007-9472-0293"
+repository-code: "https://github.com/medizininformatik-initiative/torch"
+url: "https://medizininformatik-initiative.github.io/torch/"
+license: Apache-2.0
+version: 1.0.0-beta.2
+date-released: "2026-05-15"
+keywords:
+  - FHIR
+  - medical-informatics
+  - clinical-data-extraction
+  - cohort-selection
+  - pseudonymization
+  - consent
+  - health-data


### PR DESCRIPTION
## Summary
- Adds `CITATION.cff` at the repository root following CFF 1.2.0
- Lists all four authors with ORCID identifiers
- Reflects current version (1.0.0-beta.2) and release date (2026-05-15)
- GitHub will surface a "Cite this repository" button automatically once merged

## Test plan
- [ ] Verify GitHub shows "Cite this repository" on the repo homepage after merge

Closes #953