### PR TITLE
Explore replacing hapi-fhir framework layer with org.hl7.fhir.r4 directly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,12 +65,7 @@
             <version>${Hapi.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>ca.uhn.hapi.fhir</groupId>
-            <artifactId>hapi-fhir-client</artifactId>
-            <version>${Hapi.version}</version>
-        </dependency>
-
+        <!-- provides profiles-types.xml, loaded by HapiWorkerContext for FHIRPath .ofType() resolution -->
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-validation-resources-r4</artifactId>
@@ -79,14 +74,21 @@
 
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
-            <artifactId>hapi-fhir-validation</artifactId>
+            <artifactId>hapi-fhir-caching-caffeine</artifactId>
             <version>${Hapi.version}</version>
         </dependency>
 
+        <!-- ucum was pulled transitively via hapi-fhir-validation (now removed); declared optional in org.hl7.fhir.r4 -->
         <dependency>
-            <groupId>ca.uhn.hapi.fhir</groupId>
-            <artifactId>hapi-fhir-caching-caffeine</artifactId>
-            <version>${Hapi.version}</version>
+            <groupId>org.fhir</groupId>
+            <artifactId>ucum</artifactId>
+            <version>1.0.9</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Overriding org.hl7.fhir.core modules that come from hapi-fhir-structures-r4/validation

--- a/pom.xml
+++ b/pom.xml
@@ -67,12 +67,7 @@
             <version>${Hapi.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>ca.uhn.hapi.fhir</groupId>
-            <artifactId>hapi-fhir-client</artifactId>
-            <version>${Hapi.version}</version>
-        </dependency>
-
+        <!-- provides profiles-types.xml, loaded by HapiWorkerContext for FHIRPath .ofType() resolution -->
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-validation-resources-r4</artifactId>
@@ -81,14 +76,21 @@
 
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
-            <artifactId>hapi-fhir-validation</artifactId>
+            <artifactId>hapi-fhir-caching-caffeine</artifactId>
             <version>${Hapi.version}</version>
         </dependency>
 
+        <!-- ucum was pulled transitively via hapi-fhir-validation (now removed); declared optional in org.hl7.fhir.r4 -->
         <dependency>
-            <groupId>ca.uhn.hapi.fhir</groupId>
-            <artifactId>hapi-fhir-caching-caffeine</artifactId>
-            <version>${Hapi.version}</version>
+            <groupId>org.fhir</groupId>
+            <artifactId>ucum</artifactId>
+            <version>1.0.9</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Overriding org.hl7.fhir.core modules that come from hapi-fhir-structures-r4/validation


### PR DESCRIPTION
## Summary

- Removes `hapi-fhir-client` and `hapi-fhir-validation` — both were declared in the pom but unused in production code
- Makes `org.fhir:ucum` an explicit dependency — it was silently provided by `hapi-fhir-validation`; needed by `FhirPathR4` at init time but declared `optional` in `org.hl7.fhir.r4`
- Keeps `hapi-fhir-validation-resources-r4` — provides `profiles-types.xml` which `HapiWorkerContext` loads to register FHIR types for FHIRPath `.ofType()` resolution; not imported anywhere but silently required at runtime

## Context

See #958 for the full analysis. This is the safe Tier 1 step. Tier 2 (replacing `FhirContext`/`FhirPathR4` with `FHIRPathEngine` + `SimpleWorkerContext` directly, allowing `hapi-fhir-structures-r4` and `hapi-fhir-validation-resources-r4` to also be dropped) remains a follow-up.

## Test plan

- All 1012 unit tests pass