### PR TITLE
Reject non-DomainResource attribute groups in CrtdlValidatorService

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/torch/service/CrtdlValidatorService.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/service/CrtdlValidatorService.java
@@ -1,5 +1,6 @@
 package de.medizininformatikinitiative.torch.service;
 
+import ca.uhn.fhir.context.FhirContext;
 import de.medizininformatikinitiative.torch.exceptions.ConsentFormatException;
 import de.medizininformatikinitiative.torch.exceptions.ValidationException;
 import de.medizininformatikinitiative.torch.management.StructureDefinitionHandler;
@@ -15,6 +16,7 @@ import de.medizininformatikinitiative.torch.model.management.TermCode;
 import de.medizininformatikinitiative.torch.util.CompiledStructureDefinition;
 import de.medizininformatikinitiative.torch.util.FhirPathBuilder;
 import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.r4.model.DomainResource;
 import org.hl7.fhir.r4.model.ElementDefinition;
 import org.hl7.fhir.r4.model.Property;
 import org.slf4j.Logger;
@@ -37,12 +39,14 @@ public class CrtdlValidatorService {
     private final CrtdlConsentValidator crtdlConsentValidator = new CrtdlConsentValidator();
     private final ConsentCodeConfig consentCodeConfig;
     private final FhirPathBuilder fhirPathBuilder;
+    private final FhirContext fhirContext;
 
-    public CrtdlValidatorService(StructureDefinitionHandler profileHandler, StandardAttributeGenerator attributeGenerator, ConsentCodeConfig consentCodeConfig, FhirPathBuilder fhirPathBuilder) {
+    public CrtdlValidatorService(StructureDefinitionHandler profileHandler, StandardAttributeGenerator attributeGenerator, ConsentCodeConfig consentCodeConfig, FhirPathBuilder fhirPathBuilder, FhirContext fhirContext) {
         this.profileHandler = profileHandler;
         this.attributeGenerator = attributeGenerator;
         this.consentCodeConfig = consentCodeConfig;
         this.fhirPathBuilder = fhirPathBuilder;
+        this.fhirContext = fhirContext;
     }
 
     /**
@@ -65,6 +69,12 @@ public class CrtdlValidatorService {
         for (AttributeGroup attributeGroup : crtdl.dataExtraction().attributeGroups()) {
             CompiledStructureDefinition definition = profileHandler.getDefinition(attributeGroup.groupReference())
                     .orElseThrow(() -> new ValidationException("Unknown Profile: " + attributeGroup.groupReference()));
+            Class<?> implementingClass = fhirContext.getResourceDefinition(definition.type()).getImplementingClass();
+            if (!DomainResource.class.isAssignableFrom(implementingClass)) {
+                throw new ValidationException("Profile " + attributeGroup.groupReference() +
+                        " maps to resource type " + definition.type() +
+                        ", which is not a DomainResource. Only DomainResource types are supported.");
+            }
             if (Objects.equals(definition.type(), "Patient")) {
                 if (exactlyOnePatientGroup) {
                     throw new ValidationException(" More than one Patient Attribute Group");

--- a/src/test/java/de/medizininformatikinitiative/torch/service/CrtdlValidatorServiceTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/service/CrtdlValidatorServiceTest.java
@@ -22,6 +22,7 @@ import de.medizininformatikinitiative.torch.util.CompiledStructureDefinition;
 import de.medizininformatikinitiative.torch.util.FhirPathBuilder;
 import org.hl7.fhir.r4.model.ElementDefinition;
 import org.hl7.fhir.r4.model.StructureDefinition;
+import ca.uhn.fhir.context.FhirContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -44,7 +45,7 @@ class CrtdlValidatorServiceTest {
     private final IntegrationTestSetup itSetup = new IntegrationTestSetup();
     private final CrtdlValidatorService validatorService = new CrtdlValidatorService(itSetup.structureDefinitionHandler(),
             new StandardAttributeGenerator(new CompartmentManager("compartmentdefinition-patient.json"), itSetup.structureDefinitionHandler()),
-            new ConsentCodeConfig(List.of()), itSetup.fhirPathBuilder());
+            new ConsentCodeConfig(List.of()), itSetup.fhirPathBuilder(), itSetup.fhirContext());
 
     @Mock
     StructureDefinitionHandler mockHandler;
@@ -84,6 +85,16 @@ class CrtdlValidatorServiceTest {
 
         assertThatThrownBy(() -> validatorService.validateAndAnnotate(crtdl)).isInstanceOf(ConsentFormatException.class)
                 .hasMessageContaining("Exclusion criteria must not contain Einwilligung consent codes.");
+    }
+
+    @Test
+    void nonDomainResourceProfile() {
+        Crtdl crtdl = new Crtdl(node, new DataExtraction(List.of(patientGroup,
+                new AttributeGroup("binaryGroup", "https://gematik.de/fhir/isik/StructureDefinition/ISiKBinary", List.of(), List.of()))));
+
+        assertThatThrownBy(() -> validatorService.validateAndAnnotate(crtdl)).isInstanceOf(ValidationException.class)
+                .hasMessageContaining("Binary")
+                .hasMessageContaining("not a DomainResource");
     }
 
     @Test
@@ -190,7 +201,7 @@ class CrtdlValidatorServiceTest {
         when(mockFhirPathBuilder.resolve(eq("Observation.component:someSlice.code"), any()))
                 .thenReturn(new String[]{"Observation.component", "Observation.component"});
 
-        CrtdlValidatorService svc = new CrtdlValidatorService(mockHandler, mockAttributeGenerator, new ConsentCodeConfig(List.of()), mockFhirPathBuilder);
+        CrtdlValidatorService svc = new CrtdlValidatorService(mockHandler, mockAttributeGenerator, new ConsentCodeConfig(List.of()), mockFhirPathBuilder, FhirContext.forR4());
 
         AttributeGroup patientGroup = new AttributeGroup("patientGroupId", "patient-profile", List.of(), List.of());
         AttributeGroup obsGroup = new AttributeGroup("obsGroupId", "obs-profile",
@@ -237,7 +248,7 @@ class CrtdlValidatorServiceTest {
         when(mockFhirPathBuilder.resolve(eq("Observation.component:someSlice.code"), any()))
                 .thenReturn(new String[]{"Observation.component", "Observation.component"});
 
-        CrtdlValidatorService svc = new CrtdlValidatorService(mockHandler, mockAttributeGenerator, new ConsentCodeConfig(List.of()), mockFhirPathBuilder);
+        CrtdlValidatorService svc = new CrtdlValidatorService(mockHandler, mockAttributeGenerator, new ConsentCodeConfig(List.of()), mockFhirPathBuilder, FhirContext.forR4());
 
         AttributeGroup patientGroup = new AttributeGroup("patientGroupId", "patient-profile", List.of(), List.of());
         AttributeGroup obsGroup = new AttributeGroup("obsGroupId", "obs-profile",
@@ -260,7 +271,7 @@ class CrtdlValidatorServiceTest {
                 itSetup.structureDefinitionHandler(),
                 new StandardAttributeGenerator(new CompartmentManager("compartmentdefinition-patient.json"), itSetup.structureDefinitionHandler()),
                 new ConsentCodeConfig(List.of()),
-                mockFhirPathBuilder);
+                mockFhirPathBuilder, itSetup.fhirContext());
 
         String postalCode = "Patient.address:Strassenanschrift.postalCode";
         String discriminator = "Patient.address:Strassenanschrift.type";


### PR DESCRIPTION
## Summary

- Injects `FhirContext` into `CrtdlValidatorService` and adds a guard in `validateAndAnnotate()` that rejects attribute groups whose resolved FHIR type does not extend `DomainResource`
- Throws `ValidationException` with a clear message (resource type name included) at job-creation time, returning a 400 instead of a `ClassCastException` mid-batch
- Adds a test covering the ISiKBinary profile, which is present in the loaded ontology and would previously crash `DirectResourceLoader` at batch time

## Test plan

- [ ] `CrtdlValidatorServiceTest` — all 12 tests pass, including new `nonDomainResourceProfile` test
- [ ] Manually submit a CRTDL with `groupReference: "https://gematik.de/fhir/isik/StructureDefinition/ISiKBinary"` and confirm 400 with message containing "Binary" and "not a DomainResource"

Closes #961