### PR TITLE
Check output directory is writable at startup

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/torch/config/OutputDirectoryCheck.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/config/OutputDirectoryCheck.java
@@ -1,0 +1,48 @@
+package de.medizininformatikinitiative.torch.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@Component
+@Profile("!test")
+public class OutputDirectoryCheck implements ApplicationRunner {
+
+    private static final Logger logger = LoggerFactory.getLogger(OutputDirectoryCheck.class);
+
+    private final Path outputDir;
+
+    @Autowired
+    public OutputDirectoryCheck(TorchProperties torchProperties) {
+        this(Paths.get(torchProperties.results().dir()).toAbsolutePath());
+    }
+
+    OutputDirectoryCheck(Path outputDir) {
+        this.outputDir = outputDir;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        logger.info("Checking output directory is writable: {}", outputDir);
+        try {
+            Files.createDirectories(outputDir);
+            Path probe = outputDir.resolve(".write-check");
+            Files.deleteIfExists(probe);
+            Files.createFile(probe);
+            Files.delete(probe);
+            logger.info("Output directory is writable: {}", outputDir);
+        } catch (IOException e) {
+            logger.warn("Output directory is not writable: {} — jobs will fail to write results. " +
+                    "Check ownership and permissions (torch runs as uid 1000). Error: {}", outputDir, e.getMessage());
+        }
+    }
+}

--- a/src/test/java/de/medizininformatikinitiative/torch/config/OutputDirectoryCheckTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/config/OutputDirectoryCheckTest.java
@@ -1,0 +1,46 @@
+package de.medizininformatikinitiative.torch.config;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class OutputDirectoryCheckTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void run_doesNotThrowOnWritableDirectory() {
+        var check = new OutputDirectoryCheck(tempDir);
+        assertThatNoException().isThrownBy(() -> check.run(null));
+    }
+
+    @Test
+    void run_createsDirectoryIfAbsent() throws Exception {
+        Path absent = tempDir.resolve("new-output");
+        var check = new OutputDirectoryCheck(absent);
+        check.run(null);
+        assertThatNoException().isThrownBy(() -> check.run(null));
+    }
+
+    @Test
+    void run_doesNotThrowOnNonWritableDirectory() throws IOException {
+        Path readOnly = tempDir.resolve("readonly");
+        Files.createDirectories(readOnly);
+        assertThat(readOnly.toFile().setWritable(false))
+                .as("Failed to mark test directory as non-writable").isTrue();
+        try {
+            var check = new OutputDirectoryCheck(readOnly);
+            assertThatNoException().isThrownBy(() -> check.run(null));
+        } finally {
+            assertThat(readOnly.toFile().setWritable(true))
+                    .as("Failed to restore write permission on test directory: %s", readOnly).isTrue();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `OutputDirectoryCheck` implementing `ApplicationRunner` (same pattern as `FhirServerConnectivityCheck`)
- At startup, creates the output directory if absent, then writes and deletes a probe file
- Logs a clear warning with the path and a hint about uid 1000 ownership if the check fails — non-fatal

Closes #986