### PR TITLE
Fix certificate loading via /app/certs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM eclipse-temurin:25.0.3_9-jre-alpine@sha256:c707c0d18cb9e8556380719f80d96a75
 ENV JAVA_TOOL_OPTIONS="-Xmx4g"
 ENV CERTIFICATE_PATH=/app/certs
 ENV TRUSTSTORE_PATH=/app/truststore
-ENV TRUSTSTORE_FILE=self-signed-truststore.jks
 
 COPY target/torch.jar /app/
 COPY mappings  /app/mappings

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,8 @@ services:
       - "torch-data-store:/app/output"   # Shared volume with torch-nginx
       - ./structureDefinitions:/app/StructureDefinitions
       - ./output:/app/output
-    user: 1000:1000
+      - ./certs:/app/certs
+    user: 1001:1001
 
 volumes:
   data-store-data:


### PR DESCRIPTION
## Summary

- Remove `ENV TRUSTSTORE_FILE=self-signed-truststore.jks` from the Dockerfile — this was baked into the image and caused the entrypoint to always take the pre-configured truststore branch, making the `.pem` auto-loading path unreachable (#988)
- Add `./certs:/app/certs` volume mount to docker-compose.yml so users can provide CA certificates (#989)
- Fix `user: 1000:1000` → `user: 1001:1001` in docker-compose.yml to match the Dockerfile's `chown 1001:1001`, allowing keytool to write the generated truststore (#989)

## Test plan

- [ ] Place a CA certificate as `certs/ca.pem`, start with `docker compose up`, verify startup logs show `### ADDING CERT: certs/ca.pem` and `Certificate was added to keystore`
- [ ] Verify TORCH can connect to a FHIR server using a certificate signed by that CA
- [ ] Verify TORCH still starts correctly with no `certs/` files (no-cert path unchanged)