### PR TITLE
Fix CascadingDelete silently skipping must-have escalation for shared reference targets

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/torch/service/CascadingDelete.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/service/CascadingDelete.java
@@ -148,25 +148,21 @@ public class CascadingDelete {
         Set<ResourceAttribute> resourceAttributes = resourceBundle.childResourceGroupToResourceAttributesMap().getOrDefault(childRG, Set.of());
 
         for (ResourceAttribute resourceAttribute : resourceAttributes) {
-            boolean wasLastChild = resourceBundle.removeParentAttributeFromChildRG(childRG, resourceAttribute);
-            resourceBundle.removeChildRGFromAttribute(childRG, resourceAttribute);
+            resourceBundle.removeParentAttributeFromChildRG(childRG, resourceAttribute);
+            boolean attributeHasNoValidChildrenLeft = resourceBundle.removeChildRGFromAttribute(childRG, resourceAttribute);
 
-            if (wasLastChild) {
-                resourceBundle.setResourceAttributeInValid(resourceAttribute);
+            // If the attribute has no valid children left and it's must-have, escalate to all parent groups of the attribute
+            if (attributeHasNoValidChildrenLeft && resourceAttribute.annotatedAttribute().mustHave()) {
+                Set<ResourceGroup> parentGroups = resourceBundle.resourceAttributeToParentResourceGroup()
+                        .getOrDefault(resourceAttribute, Set.of());
 
-                // If it's a must-have attribute, escalate to all parent groups of the attribute
-                if (resourceAttribute.annotatedAttribute().mustHave()) {
-                    Set<ResourceGroup> parentGroups = resourceBundle.resourceAttributeToParentResourceGroup()
-                            .getOrDefault(resourceAttribute, Set.of());
+                // Add all parent groups to be invalidated
+                resourceGroups.addAll(parentGroups);
 
-                    // Add all parent groups to be invalidated
-                    resourceGroups.addAll(parentGroups);
-
-                    // Ensure invalidation is applied recursively
-                    for (ResourceGroup parentGroup : parentGroups) {
-                        resourceBundle.removeAttributefromParentRG(parentGroup, resourceAttribute);
-                        resourceBundle.addResourceGroupValidity(parentGroup, false);
-                    }
+                // Ensure invalidation is applied recursively
+                for (ResourceGroup parentGroup : parentGroups) {
+                    resourceBundle.removeAttributefromParentRG(parentGroup, resourceAttribute);
+                    resourceBundle.addResourceGroupValidity(parentGroup, false);
                 }
             }
         }

--- a/src/test/java/de/medizininformatikinitiative/torch/service/CascadingDeleteTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/service/CascadingDeleteTest.java
@@ -464,6 +464,55 @@ class CascadingDeleteTest {
 
             assertThat(result).containsExactlyInAnyOrder(parentResourceGroup1, parentResourceGroup2);
         }
+
+        @Test
+        void everyMustHaveAttributeSharingATargetIsEscalated() {
+            // Three DISTINCT attributes, owned by three different resources, all reference the same
+            // resourceGroup and are each must-have. "wasLastChild" must be evaluated per attribute:
+            // whichever attribute happens to be processed last in the shared target's incoming set must
+            // not be the only one escalated - each attribute independently lost its only child.
+            ResourceGroup parentResourceGroup3 = new ResourceGroup(rid("r/resourceP3"), "group5");
+            groupMap.put("group5", new AnnotatedAttributeGroup("", "group5", "", "", List.of(), List.of(), true));
+
+            ResourceAttribute mustHaveAttribute1 = new ResourceAttribute(rid("r/mustHaveOwner1"), new AnnotatedAttribute("mustHaveAttr1", "test", true));
+            ResourceAttribute mustHaveAttribute2 = new ResourceAttribute(rid("r/mustHaveOwner2"), new AnnotatedAttribute("mustHaveAttr2", "test", true));
+            ResourceAttribute mustHaveAttribute3 = new ResourceAttribute(rid("r/mustHaveOwner3"), new AnnotatedAttribute("mustHaveAttr3", "test", true));
+
+            resourceBundle.addAttributeToParent(mustHaveAttribute1, parentResourceGroup1);
+            resourceBundle.addAttributeToChild(mustHaveAttribute1, resourceGroup);
+
+            resourceBundle.addAttributeToParent(mustHaveAttribute2, parentResourceGroup2);
+            resourceBundle.addAttributeToChild(mustHaveAttribute2, resourceGroup);
+
+            resourceBundle.addAttributeToParent(mustHaveAttribute3, parentResourceGroup3);
+            resourceBundle.addAttributeToChild(mustHaveAttribute3, resourceGroup);
+
+            resourceBundle.setResourceAttributeValid(mustHaveAttribute1);
+            resourceBundle.setResourceAttributeValid(mustHaveAttribute2);
+            resourceBundle.setResourceAttributeValid(mustHaveAttribute3);
+
+            Set<ResourceGroup> result = cascadingDelete.handleParents(resourceBundle, resourceGroup);
+
+            assertThat(result).containsExactlyInAnyOrder(parentResourceGroup1, parentResourceGroup2, parentResourceGroup3);
+        }
+
+        @Test
+        void mustHaveAttributeWithRemainingChildIsNotEscalated() {
+            // mustHaveAttribute references TWO children: resourceGroup and resourceGroup2.
+            // Losing resourceGroup alone must not invalidate the attribute or escalate to its
+            // parent, since resourceGroup2 is still a valid child.
+            ResourceAttribute mustHaveAttribute = new ResourceAttribute(rid("r/mustHaveMultiChild"), new AnnotatedAttribute("mustHaveMultiChild", "test", true));
+
+            resourceBundle.addAttributeToParent(mustHaveAttribute, parentResourceGroup1);
+            resourceBundle.addAttributeToChild(mustHaveAttribute, resourceGroup);
+            resourceBundle.addAttributeToChild(mustHaveAttribute, resourceGroup2);
+            resourceBundle.setResourceAttributeValid(mustHaveAttribute);
+
+            Set<ResourceGroup> result = cascadingDelete.handleParents(resourceBundle, resourceGroup);
+
+            assertThat(result).isEmpty();
+            assertThat(resourceBundle.resourceAttributeValid(mustHaveAttribute)).isTrue();
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Summary
- `handleParents` computed whether an attribute lost its last valid child by checking the *target*'s aggregate incoming-attribute set, instead of the attribute's own remaining children — so when two distinct attributes (from different resources) referenced the same dying target, only whichever happened to be processed last (arbitrary `Set` iteration order) had its must-have escalation fire, silently dropping the other.
- Fixed by gating escalation on `removeChildRGFromAttribute`'s return value, which already tracks each attribute's own remaining children (mirrors how `handleChildren` does the equivalent check on the other side of the graph).

## Test plan
- [x] Added `everyMustHaveAttributeSharingATargetIsEscalated` (three distinct must-have attributes from different owners sharing one target); verified it deterministically fails on the old code (only 1 of 3 parents escalated) and passes on the fix (all 3).
- [x] `mvn -Dtest=CascadingDeleteTest test` — 14/14 pass.
- [x] `mvn -Dtest=ExtractDataServiceTest test` — 11/11 pass.

Closes #1046