### PR TITLE
Fix Job.initBatches resetting version to 0, breaking optimistic concurrency

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/torch/jobhandling/Job.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/jobhandling/Job.java
@@ -549,7 +549,7 @@ public record Job(
                 parameters,
                 priority,
                 coreState,
-                0L
+                version
         );
     }
 

--- a/src/test/java/de/medizininformatikinitiative/torch/jobhandling/JobTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/jobhandling/JobTest.java
@@ -793,6 +793,25 @@ public class JobTest {
         }
 
         @Test
+        void cohortSuccessPreservesVersion() {
+            UUID batchId = UUID.randomUUID();
+
+            Job job = Job.init(UUID.randomUUID(), TestUtils.emptyJobParams())
+                    .withStatus(JobStatus.RUNNING_GET_COHORT)
+                    .withCohortState(WorkUnitState.startNow())
+                    .incrementVersion()
+                    .incrementVersion()
+                    .incrementVersion();
+
+            Job updated = job.onCohortSuccess(
+                    java.util.Map.of(batchId, new BatchState(batchId, WorkUnitState.initNow())),
+                    1
+            );
+
+            assertThat(updated.version()).isEqualTo(job.version());
+        }
+
+        @Test
         void cohortSuccessEmptySkipsToCore() {
             Job job = Job.init(UUID.randomUUID(), TestUtils.emptyJobParams())
                     .withStatus(JobStatus.RUNNING_GET_COHORT)


### PR DESCRIPTION
## Summary
- `Job.initBatches()` hardcoded the rebuilt job's `version` field to `0L` instead of carrying forward the current `version`, unlike every other wither on `Job`.
- `initBatches` runs on every job right after cohort-query success, so the version counter reset early in each job's lifecycle, which breaks `JobPersistenceService.changePriority()`'s optimistic-concurrency check (`VersionConflictException` if `version != expectedVersion`).
- Fix: thread `version` through in `initBatches`, matching the pattern used by `withBatchState`, `withCoreState`, `withCohortState`, `withIssuesAdded`, `withStatus`, `withPriority`, and `incrementVersion`.

## Test plan
- [x] Added `JobTest.OnCohortSuccessTests#cohortSuccessPreservesVersion`, reproducing the bug (failed with `expected: 3L but was: 0L` before the fix).
- [x] `mvn -Dtest=JobTest test` — 92 tests, all pass.
- [x] `mvn -Dtest=JobPersistenceServiceTest test` — 100 tests, all pass.

Closes #1051