### PR TITLE
Fix Open Code Scanning Alerts (jackson-databind, libexpat, p11-kit)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM eclipse-temurin:25.0.3_9-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
 
+RUN apk update && apk upgrade --no-cache
+
 ENV JAVA_TOOL_OPTIONS="-Xmx4g"
 ENV CERTIFICATE_PATH=/app/certs
 ENV TRUSTSTORE_PATH=/app/truststore

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <ontology-tag>v4.1.0</ontology-tag>
         <netty.version>4.2.15.Final</netty.version>
         <opentelemetry.version>1.62.0</opentelemetry.version>
+        <jackson-2-bom.version>2.21.5</jackson-2-bom.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Summary
- Bump `jackson-2-bom.version` to 2.21.5 to fix CVE-2026-54515 in jackson-databind (all jackson 2.x modules move together).
- Add `RUN apk update && apk upgrade --no-cache` to the Dockerfile to pick up patched Alpine `libexpat` (2.8.2-r0) and `p11-kit`/`p11-kit-trust` (0.26.2-r0), fixing 15 Trivy CVEs. The base image digest itself can't be bumped yet — Eclipse Temurin hasn't republished `eclipse-temurin:25.0.3_9-jre-alpine` since Alpine shipped these fixes, verified against the newest available Temurin build (JDK 26).

Closes #1060

## Test plan
- [x] `mvn dependency:tree -Dincludes=com.fasterxml.jackson*` confirms all jackson 2.x modules resolve to 2.21.5
- [x] `mvn -P download-ontology -B package -DskipTests` builds cleanly
- [x] Focused tests (`CrtdlTest`, `CrtdlValidatorServiceTest`, `JobPersistenceServiceTest`) pass
- [x] `docker build` succeeds; `apk info -v` inside the built image reports `libexpat-2.8.2-r0`, `p11-kit-0.26.2-r0`, `p11-kit-trust-0.26.2-r0`