### PR TITLE
Fix Shared FHIRPathEngine Race Under Concurrent parallelStream Evaluation

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/torch/util/ElementCopier.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/util/ElementCopier.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 @Component
 public class ElementCopier {
 
-    private final IFhirPath fhirPathEngine;
+    private final ThreadLocal<IFhirPath> fhirPathEngine;
 
 
     /**
@@ -28,7 +28,7 @@ public class ElementCopier {
      * @param ctx the FHIRContext to use for creating the FhirPathEngine
      */
     public ElementCopier(FhirContext ctx) {
-        this.fhirPathEngine = ctx.newFhirPath();
+        this.fhirPathEngine = FhirPathEngines.threadLocal(ctx);
     }
 
 
@@ -49,7 +49,7 @@ public class ElementCopier {
             for (var child : entry.getValue()) {
 
                 // Evaluate the elements in the source resource for this subpath
-                List<Base> elements = fhirPathEngine.evaluate(src, child.fhirPath(), Base.class);
+                List<Base> elements = fhirPathEngine.get().evaluate(src, child.fhirPath(), Base.class);
                 if (elements.isEmpty()) continue;
 
 

--- a/src/main/java/de/medizininformatikinitiative/torch/util/FhirPathEngines.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/util/FhirPathEngines.java
@@ -1,0 +1,40 @@
+package de.medizininformatikinitiative.torch.util;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.fhirpath.IFhirPath;
+
+/**
+ * Builds per-thread {@link IFhirPath} engines for classes evaluated concurrently (e.g. under
+ * {@code parallelStream()}), since {@code FHIRPathEngine} is not safe for concurrent use.
+ */
+public final class FhirPathEngines {
+
+    private FhirPathEngines() {
+    }
+
+    /**
+     * Returns a {@link ThreadLocal} that lazily builds one {@link IFhirPath} engine per thread.
+     *
+     * <p>Each engine is built using the context classloader captured when this method is called,
+     * not the classloader of whichever thread first calls {@link ThreadLocal#get()}. This matters
+     * because {@code ForkJoinPool.commonPool()} worker threads (used implicitly by
+     * {@code parallelStream()}) are not guaranteed to carry the application classloader, which
+     * breaks HAPI's {@code ServiceLoader}-based cache provider lookup inside a repackaged Spring
+     * Boot jar.
+     *
+     * @param ctx the FhirContext to use for creating engines
+     */
+    public static ThreadLocal<IFhirPath> threadLocal(FhirContext ctx) {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return ThreadLocal.withInitial(() -> {
+            Thread thread = Thread.currentThread();
+            ClassLoader previous = thread.getContextClassLoader();
+            thread.setContextClassLoader(classLoader);
+            try {
+                return ctx.newFhirPath();
+            } finally {
+                thread.setContextClassLoader(previous);
+            }
+        });
+    }
+}

--- a/src/main/java/de/medizininformatikinitiative/torch/util/ProfileMustHaveChecker.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/util/ProfileMustHaveChecker.java
@@ -16,10 +16,10 @@ import java.util.List;
 @Component
 public class ProfileMustHaveChecker {
 
-    private final IFhirPath fhirPathEngine;
+    private final ThreadLocal<IFhirPath> fhirPathEngine;
 
     public ProfileMustHaveChecker(FhirContext ctx) {
-        this.fhirPathEngine = ctx.newFhirPath();
+        this.fhirPathEngine = FhirPathEngines.threadLocal(ctx);
     }
 
     public boolean fulfilled(Resource src, AnnotatedAttributeGroup group) {
@@ -56,7 +56,7 @@ public class ProfileMustHaveChecker {
 
     public Boolean fulfilled(DomainResource src, AnnotatedAttribute attribute) {
         List<Base> elements;
-        elements = fhirPathEngine.evaluate(src, attribute.fhirPath(), Base.class);
+        elements = fhirPathEngine.get().evaluate(src, attribute.fhirPath(), Base.class);
         return !elements.isEmpty();
     }
 }

--- a/src/main/java/de/medizininformatikinitiative/torch/util/ReferenceExtractor.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/util/ReferenceExtractor.java
@@ -23,10 +23,10 @@ import java.util.stream.Stream;
 @Component
 public class ReferenceExtractor {
     private static final Logger logger = LoggerFactory.getLogger(ReferenceExtractor.class);
-    private final IFhirPath fhirPathEngine;
+    private final ThreadLocal<IFhirPath> fhirPathEngine;
 
     public ReferenceExtractor(FhirContext ctx) {
-        this.fhirPathEngine = ctx.newFhirPath();
+        this.fhirPathEngine = FhirPathEngines.threadLocal(ctx);
     }
 
     public List<ReferenceWrapper> extract(Resource resource, Map<String, AnnotatedAttributeGroup> groupMap, String groupId) throws MustHaveViolatedException {
@@ -70,7 +70,7 @@ public class ReferenceExtractor {
         if (resource == null || annotatedAttribute == null) return List.of();
 
         // Evaluate FHIRPath - library usually returns empty list, but we stream it safely
-        List<Base> elements = fhirPathEngine.evaluate(resource, annotatedAttribute.fhirPath(), Base.class);
+        List<Base> elements = fhirPathEngine.get().evaluate(resource, annotatedAttribute.fhirPath(), Base.class);
 
         List<ExtractionId> references = Optional.ofNullable(elements).orElse(List.of()).stream()
                 .filter(Objects::nonNull)

--- a/src/test/java/de/medizininformatikinitiative/torch/util/ReferenceExtractorTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/util/ReferenceExtractorTest.java
@@ -19,6 +19,12 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -456,6 +462,62 @@ class ReferenceExtractorTest {
             assertThatThrownBy(() -> spyExtractor.extract(new Condition(), localGroups, "Error"))
                     .isExactlyInstanceOf(RuntimeException.class)
                     .hasMessage("Unexpected technical error");
+        }
+    }
+
+    @Nested
+    class ConcurrentEvaluation {
+
+        // FHIRPathEngine only appends to its unsynchronized 'log' field when the evaluated
+        // path calls trace(), which is otherwise unused by torch's generated FHIRPaths. Using
+        // it here is what makes the shared-engine race deterministically reproduce.
+        private static final AnnotatedAttribute ATTRIBUTE_TRACE =
+                new AnnotatedAttribute("Condition.subject", "subject.trace('x')", false, List.of());
+
+        @Test
+        void getReferences_underConcurrentLoad_doesNotThrowOrCorruptResults() throws InterruptedException {
+            int threadCount = 16;
+            int iterationsPerThread = 2000;
+
+            ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+            CountDownLatch startLatch = new CountDownLatch(1);
+            AtomicInteger failures = new AtomicInteger();
+
+            List<Future<?>> futures = new java.util.ArrayList<>();
+            for (int t = 0; t < threadCount; t++) {
+                futures.add(pool.submit(() -> {
+                    Condition condition = new Condition();
+                    condition.setId("Condition1");
+                    condition.setSubject(new Reference("Patient/1"));
+                    startLatch.await();
+                    for (int i = 0; i < iterationsPerThread; i++) {
+                        try {
+                            List<ExtractionId> refs = referenceExtractor.getReferences(condition, ATTRIBUTE_TRACE);
+                            if (!refs.equals(List.of(ExtractionId.fromRelativeUrl("Patient/1")))) {
+                                failures.incrementAndGet();
+                            }
+                        } catch (Throwable e) {
+                            failures.incrementAndGet();
+                        }
+                    }
+                    return null;
+                }));
+            }
+
+            startLatch.countDown();
+            for (Future<?> f : futures) {
+                try {
+                    f.get();
+                } catch (Exception e) {
+                    failures.incrementAndGet();
+                }
+            }
+            pool.shutdown();
+            assertThat(pool.awaitTermination(30, TimeUnit.SECONDS)).isTrue();
+
+            assertThat(failures.get())
+                    .as("concurrent evaluate() calls on the shared FHIRPathEngine must neither throw nor return corrupted results")
+                    .isZero();
         }
     }
 


### PR DESCRIPTION
## Summary
- `ReferenceExtractor`, `ProfileMustHaveChecker`, and `ElementCopier` each held a single shared `IFhirPath` field, evaluated concurrently via `parallelStream()` in `ReferenceResolver.loadReferencesByResourceGroup` and `BatchCopierRedacter`. `FHIRPathEngine` is not safe for concurrent use.
- Switched the field to `ThreadLocal<IFhirPath>` in all three classes, so each thread builds and reuses its own engine. Both fan-out mechanisms touching these singletons (`Schedulers.boundedElastic()` and the JVM's common `ForkJoinPool`) are bounded pools, so the number of cached engine instances stays bounded for the app's lifetime.
- `ConsentValidator` already sidesteps this by calling `ctx.newFhirPath()` fresh per call and was left unchanged (already race-free, called once per resource rather than per field).
- Added `FhirPathEngines.threadLocal(FhirContext)`, a shared factory used by all three classes. It captures the context classloader at construction time (Spring's main startup thread) and applies it when lazily building each thread's engine. This is needed because `ForkJoinPool.commonPool()` worker threads don't reliably carry the application's classloader inside a repackaged Spring Boot jar, which otherwise breaks HAPI's `ServiceLoader`-based cache provider lookup (`HAPI-2200: No Cache Service Providers found`) — caught via the `blackbox-integration-tests` / `resumability` / `script-integration-test` CI failures on the first version of this fix.

## Test plan
- Added `ReferenceExtractorTest$ConcurrentEvaluation`: 16 threads × 2000 iterations evaluating a `trace()`-based FHIRPath concurrently on a shared `ReferenceExtractor`.
  - Confirmed this reproduces the race on the pre-fix code (607 failures, `ArrayIndexOutOfBoundsException`, matching the corruption the issue predicted).
  - Passes with 0 failures after the fix.
- `mvn -Dtest='ReferenceExtractorTest,ProfileMustHaveCheckerTest,ElementCopierTest' test` — 42/42 pass.
- `mvn -Dtest='ReferenceHandlerTest,ReferenceResolverTest,DirectResourceLoaderTest,BatchCopierRedacterTest' test` — 48/48 pass (downstream callers of the changed classes).
- Built `torch:latest` locally and ran `mvn -P blackbox-integration-tests -Dit.test=CdsBlackBoxIT verify` against it — reproduced the `HAPI-2200` classloader failure from CI first, then confirmed it's fixed (2/2 pass, no `HAPI-2200` in logs) after adding `FhirPathEngines`.

Closes #1084