### PR TITLE
Remove Dead Code in NonContinuousPeriod.update

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/torch/model/consent/NonContinuousPeriod.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/model/consent/NonContinuousPeriod.java
@@ -45,18 +45,6 @@ public record NonContinuousPeriod(List<Period> periods) {
         return new NonContinuousPeriod(merged);
     }
 
-    public NonContinuousPeriod update(Period encounterPeriod) {
-        return new NonContinuousPeriod(
-                periods.stream()
-                        .map(consentPeriod -> {
-                            if (consentPeriod.isStartBetween(encounterPeriod)) {
-                                return new Period(encounterPeriod.start(), consentPeriod.end());
-                            }
-                            return consentPeriod;
-                        }).toList()
-        );
-    }
-
     public boolean within(Period resourcePeriod) {
         return periods.stream().anyMatch(period ->
                 !resourcePeriod.start().isBefore(period.start()) && !resourcePeriod.end().isAfter(period.end()));

--- a/src/test/java/de/medizininformatikinitiative/torch/model/consent/NonContinuousPeriodTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/model/consent/NonContinuousPeriodTest.java
@@ -85,31 +85,6 @@ class NonContinuousPeriodTest {
     }
 
     @Nested
-    class Update {
-
-        @Test
-        void adjustsStartWhenInsideEncounter() {
-            var consent = new NonContinuousPeriod(List.of(p("2024-01-05", "2024-01-10")));
-            var encounter = p("2024-01-01", "2024-01-06");
-
-            var updated = consent.update(encounter);
-
-            assertThat(updated.periods())
-                    .containsExactly(p("2024-01-01", "2024-01-10"));
-        }
-
-        @Test
-        void leavesUnchangedIfOutside() {
-            var consent = new NonContinuousPeriod(List.of(p("2024-01-20", "2024-01-30")));
-            var encounter = p("2024-01-01", "2024-01-10");
-
-            var updated = consent.update(encounter);
-
-            assertThat(updated.periods()).containsExactly(p("2024-01-20", "2024-01-30"));
-        }
-    }
-
-    @Nested
     class Within {
 
         @Test


### PR DESCRIPTION
## Summary
- Removes `NonContinuousPeriod.update(Period)`, which has no production callers and is superseded by `ConsentProvisions.updateByEncounters`, which correctly handles multiple overlapping encounters.
- Removes the corresponding `Update` unit test.

## Test plan
- [x] `mvn -pl . -Dtest=NonContinuousPeriodTest test` — 26 tests pass
- [x] `mvn -P download-ontology -B package -DskipTests` — builds cleanly
- [x] Confirmed no other references to `NonContinuousPeriod.update` or `Period.isStartBetween` are affected (the latter is still used by `ConsentProvisions`)

Closes #1078