### PR TITLE
Add Defensive Check on Blaze MeasureReport Shape in CqlClient

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/torch/cql/CqlClient.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/cql/CqlClient.java
@@ -1,5 +1,6 @@
 package de.medizininformatikinitiative.torch.cql;
 
+import de.medizininformatikinitiative.torch.exceptions.MeasureReportShapeException;
 import de.medizininformatikinitiative.torch.model.fhir.Query;
 import de.medizininformatikinitiative.torch.model.fhir.QueryParams;
 import de.medizininformatikinitiative.torch.service.DataStore;
@@ -40,7 +41,7 @@ public class CqlClient {
 
         return dataStore.transact(measureLibraryBundle)
                 .then(Mono.defer(() -> dataStore.evaluateMeasure(params)))
-                .map(CqlClient::extractSubjectListId)
+                .map(measureReport -> extractSubjectListId(measureReport, measureUri))
                 .map(CqlClient::createPatientQuery)
                 .flux()
                 .flatMap(query -> dataStore.search(query, Patient.class))
@@ -50,12 +51,31 @@ public class CqlClient {
                 });
     }
 
-    private static String extractSubjectListId(MeasureReport measureReport) {
-        return measureReport.getGroupFirstRep()
-                .getPopulationFirstRep()
-                .getSubjectResults()
-                .getReferenceElement()
-                .getIdPart();
+    /**
+     * Extracts the subject list id from a {@link MeasureReport}.
+     * <p>
+     * HAPI's {@code getXxxFirstRep()} accessors silently return empty defaults instead of throwing, so an
+     * ill-shaped report (missing group, population, or subject results reference) would otherwise surface as a
+     * bare {@link NullPointerException} further downstream.
+     *
+     * @throws MeasureReportShapeException if the report has no populated group/population/subjectResults reference
+     */
+    private static String extractSubjectListId(MeasureReport measureReport, String measureUri) {
+        if (!measureReport.hasGroup() || !measureReport.getGroupFirstRep().hasPopulation()) {
+            throw new MeasureReportShapeException(measureUri);
+        }
+
+        var population = measureReport.getGroupFirstRep().getPopulationFirstRep();
+        if (!population.hasSubjectResults()) {
+            throw new MeasureReportShapeException(measureUri);
+        }
+
+        String idPart = population.getSubjectResults().getReferenceElement().getIdPart();
+        if (idPart == null) {
+            throw new MeasureReportShapeException(measureUri);
+        }
+
+        return idPart;
     }
 
     private static Query createPatientQuery(String subjectListId) {

--- a/src/main/java/de/medizininformatikinitiative/torch/exceptions/MeasureReportShapeException.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/exceptions/MeasureReportShapeException.java
@@ -1,0 +1,8 @@
+package de.medizininformatikinitiative.torch.exceptions;
+
+public class MeasureReportShapeException extends RuntimeException {
+
+    public MeasureReportShapeException(String measureUri) {
+        super("MeasureReport for measure " + measureUri + " does not contain a populated group/population/subjectResults reference");
+    }
+}

--- a/src/test/java/de/medizininformatikinitiative/torch/cql/CqlClientTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/cql/CqlClientTest.java
@@ -1,0 +1,97 @@
+package de.medizininformatikinitiative.torch.cql;
+
+import de.medizininformatikinitiative.torch.exceptions.MeasureReportShapeException;
+import de.medizininformatikinitiative.torch.model.fhir.Query;
+import de.medizininformatikinitiative.torch.service.DataStore;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.MeasureReport;
+import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Reference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CqlClientTest {
+
+    @Mock
+    FhirHelper fhirHelper;
+
+    @Mock
+    DataStore dataStore;
+
+    CqlClient cqlClient;
+
+    @BeforeEach
+    void setUp() {
+        cqlClient = new CqlClient(fhirHelper, dataStore);
+
+        when(fhirHelper.getListExecutionParams()).thenReturn(new Parameters());
+        when(fhirHelper.createBundle(any(), any(), any())).thenReturn(new Bundle());
+        when(dataStore.transact(any(Bundle.class))).thenReturn(Mono.empty());
+    }
+
+    @Test
+    void fetchPatientIds_withWellFormedMeasureReport_returnsPatientIds() {
+        var measureReport = new MeasureReport();
+        measureReport.addGroup().addPopulation().setSubjectResults(new Reference("List/list-id"));
+        when(dataStore.evaluateMeasure(any(Parameters.class))).thenReturn(Mono.just(measureReport));
+
+        var patient = new Patient();
+        patient.setId("patient-id");
+        when(dataStore.search(any(Query.class), org.mockito.ArgumentMatchers.eq(Patient.class)))
+                .thenReturn(Flux.just(patient));
+
+        StepVerifier.create(cqlClient.fetchPatientIds("cql-query"))
+                .expectNext("patient-id")
+                .verifyComplete();
+    }
+
+    @Test
+    void fetchPatientIds_withMeasureReportMissingGroup_errors() {
+        when(dataStore.evaluateMeasure(any(Parameters.class))).thenReturn(Mono.just(new MeasureReport()));
+
+        StepVerifier.create(cqlClient.fetchPatientIds("cql-query"))
+                .verifyError(MeasureReportShapeException.class);
+    }
+
+    @Test
+    void fetchPatientIds_withGroupMissingPopulation_errors() {
+        var measureReport = new MeasureReport();
+        measureReport.addGroup().setCode(new CodeableConcept().setText("group-without-population"));
+        when(dataStore.evaluateMeasure(any(Parameters.class))).thenReturn(Mono.just(measureReport));
+
+        StepVerifier.create(cqlClient.fetchPatientIds("cql-query"))
+                .verifyError(MeasureReportShapeException.class);
+    }
+
+    @Test
+    void fetchPatientIds_withMeasureReportMissingSubjectResults_errors() {
+        var measureReport = new MeasureReport();
+        measureReport.addGroup().addPopulation().setCount(1);
+        when(dataStore.evaluateMeasure(any(Parameters.class))).thenReturn(Mono.just(measureReport));
+
+        StepVerifier.create(cqlClient.fetchPatientIds("cql-query"))
+                .verifyError(MeasureReportShapeException.class);
+    }
+
+    @Test
+    void fetchPatientIds_withSubjectResultsReferenceMissingIdPart_errors() {
+        var measureReport = new MeasureReport();
+        measureReport.addGroup().addPopulation().setSubjectResults(new Reference().setDisplay("no reference string"));
+        when(dataStore.evaluateMeasure(any(Parameters.class))).thenReturn(Mono.just(measureReport));
+
+        StepVerifier.create(cqlClient.fetchPatientIds("cql-query"))
+                .verifyError(MeasureReportShapeException.class);
+    }
+}


### PR DESCRIPTION
## Summary
- `CqlClient.extractSubjectListId` validates the MeasureReport has a populated group/population/subjectResults reference before extracting the subject list id, instead of relying on HAPI's `getXxxFirstRep()` silently materializing empty defaults.
- Fails with a new `MeasureReportShapeException`, named with the measure URN (the same identifier Blaze logs for the `$evaluate-measure` call), instead of a bare `NullPointerException` further downstream.

## Test plan
- [x] `mvn -Dtest=CqlClientTest test` — new unit tests covering the well-formed case and three malformed-shape cases (missing group, missing subjectResults, subjectResults reference without an id part)
- [x] `mvn compile`

Closes #1085