### PR TITLE
Narrow Broad Exception Catch in BatchCopierRedacter

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/torch/service/BatchCopierRedacter.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/service/BatchCopierRedacter.java
@@ -57,6 +57,10 @@ public class BatchCopierRedacter {
      * <p>
      * Groups Attribute Group by Resource to which they should be applied, builds all information needed for extraction and
      * redaction and then applies it to the resources.
+     * <p>
+     * A resource that fails with {@link TargetClassCreationException}, {@link ReflectiveOperationException}, or
+     * {@link RedactionException} is isolated: it is dropped from the bundle and a warning is logged, without failing
+     * the rest of the batch. Any other exception is treated as a programming error and propagates.
      *
      * @param extractionBundle PatientResourceBundle to transform
      * @param groupMap         Immutable AttributeGroup Map shared between all Batches
@@ -82,7 +86,7 @@ public class BatchCopierRedacter {
 
                 extractionBundle.put(transformed);
 
-            } catch (Exception e) {
+            } catch (TargetClassCreationException | ReflectiveOperationException | RedactionException e) {
                 logger.warn("BatchCopierRedacter001: Error transforming resource {}: {}", resourceId, e.getMessage());
                 extractionBundle.put(resourceId);
             }

--- a/src/test/java/de/medizininformatikinitiative/torch/service/BatchCopierRedacterTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/service/BatchCopierRedacterTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -113,6 +114,19 @@ class BatchCopierRedacterTest {
         transformer.transformBundle(extractionBundle, Map.of());
 
         assertThat(extractionBundle.getResource(ExtractionId.fromRelativeUrl("Patient/dummy"))).isEmpty();
+    }
+
+    @Test
+    void transformBundle_propagatesUnexpectedRuntimeException() throws Exception {
+        doThrow(new NullPointerException("bug"))
+                .when(transformer)
+                .transformResource(any());
+
+        assertThatThrownBy(() -> transformer.transformBundle(extractionBundle, Map.of()))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("bug");
+
+        assertThat(extractionBundle.getResource(ExtractionId.fromRelativeUrl("Patient/dummy"))).isPresent();
     }
 
     @Nested


### PR DESCRIPTION
## Summary
- `BatchCopierRedacter.transformBundle` narrowed its per-resource `catch (Exception e)` to `catch (TargetClassCreationException | ReflectiveOperationException | RedactionException e)` — the exact checked exceptions `transformResource` declares as expected copy/redaction failure modes.
- Unexpected exceptions (e.g. `NullPointerException`, `ClassCastException`) now propagate instead of being silently logged and masked as routine redaction failures, surfacing as a genuine batch failure via the existing `Mono#error` / `RetryabilityUtil` path in `ProcessBatchWorkUnit`.
- Documented the fault-isolation contract on `transformBundle`'s Javadoc.

## Test plan
- [x] `mvn -Dtest=BatchCopierRedacterTest test` — added `transformBundle_propagatesUnexpectedRuntimeException`, alongside existing tests covering the three isolated exception types
- [x] `mvn compile test-compile`

Closes #1082