### PR TITLE
Redaction Handling Mismatch between Min Cardinality >1 and Child Slices

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/torch/model/management/ElementContext.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/model/management/ElementContext.java
@@ -6,6 +6,7 @@ import org.hl7.fhir.r4.model.Base;
 import org.hl7.fhir.r4.model.ElementDefinition;
 
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static java.util.Objects.requireNonNull;
 
@@ -43,5 +44,12 @@ public record ElementContext(String elementId, CompiledStructureDefinition defin
     public Optional<ElementContext> matchingSlice(Base dataElement) {
         Optional<ElementDefinition> slice = Slicing.resolveSlicing(dataElement, elementId, definition);
         return slice.map(elementDefinition -> new ElementContext(elementDefinition.getId(), definition));
+    }
+
+    /**
+     * Returns all named slices defined for this element, independent of any specific data instance.
+     */
+    Stream<ElementDefinition> definedSlices() {
+        return Slicing.definedSlices(elementId, definition);
     }
 }

--- a/src/main/java/de/medizininformatikinitiative/torch/model/management/MultiElementContext.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/model/management/MultiElementContext.java
@@ -37,10 +37,20 @@ public record MultiElementContext(List<ElementContext> contexts) {
      * @return an {@code Optional} containing the updated {@code MultiElementContext}, or empty if suppressed by the consumer
      */
     public Optional<MultiElementContext> resolveSlices(Base dataElement, Predicate<List<ElementContext>> sliceConsumer) {
-        List<ElementContext> slices = contexts.stream().filter(ElementContext::hasSlicing)
+        List<ElementContext> slices = matchingSlices(dataElement);
+        return sliceConsumer.test(slices) ? Optional.empty() : Optional.of(mergeWithSlices(slices));
+    }
+
+    /**
+     * Returns the slice contexts matching the given data element, across all associated definitions.
+     *
+     * @param dataElement HAPI Base (Element) which should be checked
+     * @return the matching slice contexts, empty if none match
+     */
+    public List<ElementContext> matchingSlices(Base dataElement) {
+        return contexts.stream().filter(ElementContext::hasSlicing)
                 .flatMap(ctx -> ctx.matchingSlice(dataElement).stream())
                 .toList();
-        return sliceConsumer.test(slices) ? Optional.empty() : Optional.of(mergeWithSlices(slices));
     }
 
     public boolean shouldRedactExtension(Extension extension) {
@@ -129,6 +139,20 @@ public record MultiElementContext(List<ElementContext> contexts) {
      */
     public boolean required() {
         return elementDefinitions().anyMatch(elementDefinition -> elementDefinition.getMin() > 0);
+    }
+
+    /**
+     * Determines named slices with minimum cardinality &gt;0 that none of the given matched slice element ids satisfy.
+     *
+     * @param matchedSliceIds element ids of slices matched by at least one existing instance
+     * @return element definitions of required slices with no matching instance
+     */
+    public List<ElementDefinition> missingRequiredSlices(Set<String> matchedSliceIds) {
+        return contexts.stream()
+                .flatMap(ElementContext::definedSlices)
+                .filter(slice -> slice.getMin() > 0)
+                .filter(slice -> !matchedSliceIds.contains(slice.getId()))
+                .toList();
     }
 
     public List<String> workingCodes() {

--- a/src/main/java/de/medizininformatikinitiative/torch/util/Redaction.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/util/Redaction.java
@@ -3,6 +3,7 @@ package de.medizininformatikinitiative.torch.util;
 import de.medizininformatikinitiative.torch.exceptions.RedactionException;
 import de.medizininformatikinitiative.torch.management.StructureDefinitionHandler;
 import de.medizininformatikinitiative.torch.model.extraction.ExtractionId;
+import de.medizininformatikinitiative.torch.model.management.ElementContext;
 import de.medizininformatikinitiative.torch.model.management.ExtractionRedactionWrapper;
 import de.medizininformatikinitiative.torch.model.management.MultiElementContext;
 import org.hl7.fhir.exceptions.FHIRException;
@@ -38,6 +39,7 @@ public class Redaction {
     private static final String MASKED = "masked";
     private static final Extension ABSENT_REASON_EXTENSION = createAbsentReasonExtension(MASKED);
     private static final String EXTENSION = "extension";
+    private static final String MODIFIER_EXTENSION = "modifierExtension";
     private static final String REFERENCE = "reference";
 
     private final StructureDefinitionHandler structureDefinitionHandler;
@@ -242,13 +244,52 @@ public class Redaction {
 
                     handleReference(child, childContexts.allowedReferences(references));
                 }
+                boolean checkSlices = !EXTENSION.equals(child.getName()) && !MODIFIER_EXTENSION.equals(child.getName());
+                Set<String> matchedSliceIds = checkSlices ? matchedSliceIds(child, childContexts) : Set.of();
                 for (Base value : child.getValues()) {
                     redact(value, childContexts, references);
+                }
+                // Only flag missing required slices if at least one instance matched some slice; otherwise none of
+                // the values addressed slicing at all, and the per-instance masking above already covers them.
+                if (!matchedSliceIds.isEmpty()) {
+                    childContexts.missingRequiredSlices(matchedSliceIds)
+                            .forEach(slice -> addMissingSlice(baseElement, child, slice));
                 }
             } else if (child.getMinCardinality() > 0 || childContexts.required()) {
                 addDataAbsentReason(baseElement, child, types.getFirst());
             }
         });
+    }
+
+    /**
+     * Collects the element ids of slices matched by at least one existing value of {@code child}.
+     * <p>
+     * Must be evaluated before {@code child}'s values are redacted, since redaction wipes the children
+     * of instances that match no slice, which would make them unmatchable afterwards.
+     * </p>
+     */
+    private Set<String> matchedSliceIds(Property child, MultiElementContext childContexts) {
+        return child.getValues().stream()
+                .flatMap(value -> childContexts.matchingSlices(value).stream())
+                .map(ElementContext::elementId)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Appends a masked stub value of the given slice's type, representing a required named slice with no
+     * matching instance among the existing values of {@code child}.
+     * <p>
+     * Slices defined via {@code contentReference} rather than {@code type} carry no type of their own; such a
+     * slice is logged and skipped, since there is no type to build a masked stub from.
+     * </p>
+     */
+    private void addMissingSlice(Base base, Property child, ElementDefinition slice) {
+        List<String> sliceTypes = slice.getType().stream().map(ElementDefinition.TypeRefComponent::getWorkingCode).toList();
+        if (sliceTypes.isEmpty()) {
+            logger.warn("Missing type for required slice {} in field {} of {}", slice.getId(), child.getName(), base.fhirType());
+            return;
+        }
+        addDataAbsentReason(base, child, sliceTypes.getFirst());
     }
 
     /**

--- a/src/main/java/de/medizininformatikinitiative/torch/util/Slicing.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/util/Slicing.java
@@ -84,6 +84,21 @@ public class Slicing {
     }
 
     /**
+     * Returns all named slices defined for the sliced element identified by {@code elementId}, independent of any
+     * specific data instance.
+     *
+     * @param elementId  Element ID of the sliced (parent) element.
+     * @param definition definition of the Resource to which the element belongs
+     * @return Stream of the named slice ElementDefinitions; empty if the element is not sliced or unknown.
+     */
+    public static Stream<ElementDefinition> definedSlices(String elementId, CompiledStructureDefinition definition) {
+        return definition.elementDefinitionById(elementId)
+                .filter(ElementDefinition::hasSlicing)
+                .map(sliced -> definition.elementDefinitionByPath(sliced.getPath()).filter(ElementDefinition::hasSliceName))
+                .orElseGet(Stream::empty);
+    }
+
+    /**
      * Generates FHIR Path conditions based on the element ID and the snapshot of the StructureDefinition.
      *
      * @param elementID  ElementID that needs to be resolved

--- a/src/test/java/de/medizininformatikinitiative/torch/util/RedactionTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/util/RedactionTest.java
@@ -18,6 +18,7 @@ import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Medication;
 import org.hl7.fhir.r4.model.Meta;
+import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.StringType;
@@ -210,6 +211,34 @@ public class RedactionTest {
 
     }
 
+    /**
+     * Tests a required named slice ({@code min=1}) defined via {@code contentReference} instead of {@code type}
+     * (a valid FHIR construct, e.g. for recursive structures). With no matching instance in the data, the
+     * missing-slice masking has no type to build a stub from and must skip that slice instead of failing.
+     *
+     * @throws IOException when test file not found
+     */
+    @Test
+    void missingRequiredSliceWithoutType() throws IOException, RedactionException {
+        Observation src = new Observation();
+        Meta meta = new Meta();
+        meta.addProfile("http://example.org/fhir/StructureDefinition/observation-with-typeless-required-slice");
+        src.setMeta(meta);
+        src.setStatus(Observation.ObservationStatus.FINAL);
+        src.setCode(new CodeableConcept(new Coding("http://loinc.org", "85353-1", "Vital signs panel")));
+        Observation.ObservationComponentComponent heartRate = new Observation.ObservationComponentComponent();
+        heartRate.setCode(new CodeableConcept(new Coding("http://loinc.org", "8867-4", "Heart rate")));
+        src.setComponent(List.of(heartRate));
+
+        StructureDefinitionHandler definitionHandler = new StructureDefinitionHandler(new File("src/test/resources/StructureDefinitions/"), new ResourceReader(integrationTestSetup.fhirContext()));
+        definitionHandler.processDirectory();
+        Redaction redaction = new Redaction(definitionHandler);
+        ExtractionRedactionWrapper wrapper = new ExtractionRedactionWrapper(src.copy(), Set.of("http://example.org/fhir/StructureDefinition/observation-with-typeless-required-slice"), Map.of(), new CopyTreeNode("dummy"));
+        DomainResource tgt = redaction.redact(wrapper);
+
+        assertThat(fhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(tgt)).isEqualTo(fhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(src));
+    }
+
     @Nested
     class ConditionTest {
 
@@ -268,10 +297,11 @@ public class RedactionTest {
          * @param resource Todesursache1.json does only contain the who icd10 (who) which is not currently allowed in diagnosis profile
          *                 Todesursache2.json does contain 2 legal codings icd10 and sct from two different profiles
          *                 Todesursache3.json does not contain the required icd 10 (who)
+         *                 Todesursache4.json only contains one of the two required category.coding slices (snomed, missing loinc)
          * @throws IOException when test file not found
          */
         @ParameterizedTest
-        @ValueSource(strings = {"Todesursache1.json", "Todesursache2.json", "Todesursache3.json"})
+        @ValueSource(strings = {"Todesursache1.json", "Todesursache2.json", "Todesursache3.json", "Todesursache4.json"})
         void testMultipleProfiles(String resource) throws IOException, RedactionException {
             DomainResource src = integrationTestSetup.readResource(INPUT_CONDITION_DIR + resource);
             DomainResource expected = integrationTestSetup.readResource(EXPECTED_OUTPUT_DIR + resource);
@@ -361,6 +391,30 @@ public class RedactionTest {
             dar.setReferenceElement(referenceElement);
             expected.setSubject(dar);
             assertThat(fhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(tgt)).isEqualTo(fhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(expected));
+        }
+
+        /**
+         * modifierExtension, like extension, is handled by the URL-aware extension pipeline rather than
+         * slice-matching, so it must pass through untouched instead of being checked for missing required slices.
+         */
+        @Test
+        void modifierExtensionSkipsSliceCheck() throws RedactionException {
+            Encounter src = new Encounter();
+            Meta meta = new Meta();
+            meta.setProfile(List.of(new CanonicalType(ENCOUNTER)));
+            src.setMeta(meta);
+            src.setStatus(Encounter.EncounterStatus.ARRIVED);
+            src.setClass_(new Coding("Test", "Test", "Test"));
+            src.setId("Encounter/12345");
+            src.setSubject(new Reference("Patient/12345"));
+            src.setDiagnosis(List.of(new Encounter.DiagnosisComponent().setCondition(new Reference("Condition/12345")).setUse(new CodeableConcept(new Coding("Test", "Test", "")))));
+            src.addModifierExtension(new Extension("http://example.org/fhir/StructureDefinition/some-modifier-extension", new StringType("value")));
+
+            ExtractionRedactionWrapper wrapper = new ExtractionRedactionWrapper(src.copy(), Set.of(ENCOUNTER), Map.of("Encounter.subject", ExtractionId.of("Patient/12345", "Patient/123"), "Encounter.diagnosis", ExtractionId.of("Condition/12345")), new CopyTreeNode("dummy"));
+            var redaction = integrationTestSetup.redaction();
+            Encounter tgt = (Encounter) redaction.redact(wrapper);
+
+            assertThat(fhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(tgt)).isEqualTo(fhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(src));
         }
 
         @Test

--- a/src/test/resources/InputResources/Condition/Todesursache4.json
+++ b/src/test/resources/InputResources/Condition/Todesursache4.json
@@ -1,0 +1,29 @@
+{
+  "resourceType": "Condition",
+  "id": "Diagnose1",
+  "meta": {
+    "profile": [
+      "https://www.medizininformatik-initiative.de/fhir/core/modul-person/StructureDefinition/Todesursache",
+      "https://www.medizininformatik-initiative.de/fhir/core/modul-diagnose/StructureDefinition/Diagnose"
+    ]
+  },
+  "category": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16100001"
+      }
+    ]
+  },
+  "code": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/123"
+  },
+  "onsetDateTime": "2024-10"
+}

--- a/src/test/resources/RedactTest/expectedOutput/Todesursache3.json
+++ b/src/test/resources/RedactTest/expectedOutput/Todesursache3.json
@@ -24,6 +24,14 @@
         "version": "http://snomed.info/sct/900000000000207008/version/20230731",
         "code": "91613004",
         "display": "Contusion of elbow (disorder)"
+      },
+      {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+            "valueCode": "masked"
+          }
+        ]
       }
     ]
   },

--- a/src/test/resources/RedactTest/expectedOutput/Todesursache4.json
+++ b/src/test/resources/RedactTest/expectedOutput/Todesursache4.json
@@ -1,0 +1,63 @@
+{
+  "resourceType": "Condition",
+  "id": "Diagnose1",
+  "meta": {
+    "profile": [
+      "https://www.medizininformatik-initiative.de/fhir/core/modul-person/StructureDefinition/Todesursache",
+      "https://www.medizininformatik-initiative.de/fhir/core/modul-diagnose/StructureDefinition/Diagnose"
+    ]
+  },
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "16100001"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+              "valueCode": "masked"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "code": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10",
+        "_version": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+              "valueCode": "masked"
+            }
+          ]
+        },
+        "_code": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+              "valueCode": "masked"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/123"
+  },
+  "onsetDateTime": "2024-10",
+  "_recordedDate": {
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+        "valueCode": "masked"
+      }
+    ]
+  }
+}

--- a/src/test/resources/StructureDefinitions/observation-with-typeless-required-slice.json
+++ b/src/test/resources/StructureDefinitions/observation-with-typeless-required-slice.json
@@ -1,0 +1,74 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "observation-with-typeless-required-slice",
+  "url": "http://example.org/fhir/StructureDefinition/observation-with-typeless-required-slice",
+  "version": "1.0.0",
+  "name": "ObservationWithTypelessRequiredSlice",
+  "status": "draft",
+  "date": "2025-07-23",
+  "kind": "resource",
+  "abstract": false,
+  "type": "Observation",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Observation",
+  "derivation": "constraint",
+  "snapshot": {
+    "element": [
+      {
+        "id": "Observation.component",
+        "path": "Observation.component",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "pattern",
+              "path": "code"
+            }
+          ],
+          "rules": "open"
+        }
+      },
+      {
+        "id": "Observation.component:heartRate",
+        "path": "Observation.component",
+        "sliceName": "heartRate",
+        "min": 1,
+        "max": "1"
+      },
+      {
+        "id": "Observation.component:heartRate.code",
+        "path": "Observation.component.code",
+        "patternCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "8867-4",
+              "display": "Heart rate"
+            }
+          ]
+        },
+        "min": 1
+      },
+      {
+        "id": "Observation.component:respiratoryRate",
+        "path": "Observation.component",
+        "sliceName": "respiratoryRate",
+        "min": 1,
+        "max": "1",
+        "contentReference": "#Observation.component:heartRate"
+      },
+      {
+        "id": "Observation.component:respiratoryRate.code",
+        "path": "Observation.component.code",
+        "patternCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "9279-1",
+              "display": "Respiratory rate"
+            }
+          ]
+        },
+        "min": 1
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

`Redaction` only checked whether a given instance of a sliced repeating element matched *any* defined slice, and whether the array as a whole was required. Neither check asked "did every individually-required named slice (`min ≥ 1`) actually get matched by at least one instance?" So when one required slice was present and a sibling required slice was missing, the missing data was silently dropped instead of getting a `data-absent-reason` marker.

This is not just a hypothetical: `RedactionTest.testMultipleProfiles` / `Todesursache3.json` already exercised the same defect on `Condition.code.coding` — a SNOMED coding legally matching Diagnose's *optional* `sct` slice masked the fact that Todesursache's *required* `icd10-who` slice was completely absent, with no DAR in the golden output.

- `Slicing.definedSlices()` / `ElementContext.definedSlices()`: enumerate all named slices defined for a sliced element, independent of any data instance.
- `MultiElementContext.matchingSlices()` / `missingRequiredSlices()`: compute which required (`min>0`) named slices got zero matching instances.
- `Redaction.redactChildren()`: for a repeating element, record which slices got matched before redacting its instances (matching must see original, pre-mutation data), then append a masked stub value for each required slice with no match. Skipped for `extension`/`modifierExtension` (handled by a separate, URL-aware pipeline) and skipped entirely when *no* instance matched any slice (that case is already covered by the existing "illegal data, mask in place" path — applying both would double-mask).

Closes #362

## Test plan
- [x] `Todesursache3.json` expected output updated — it already baked in the bug; now correctly gets a masked stub appended for the missing required `icd10-who` slice.
- [x] New `Todesursache4.json` fixture is the direct scenario from the issue: `category.coding` has only one of two required slices (`snomed` present, `loinc` missing) — `snomed` passes through untouched, a masked stub is appended for `loinc`.
- [x] `mvn -Dtest=RedactionTest test` — 36/36 pass.
- [x] `mvn -Dtest=BatchCopierRedacterTest,BatchCopierRedacterIT test` — pass (unit + Testcontainers).
- [x] Full `mvn test` — 1164 run, 0 failures; 17 errors all isolated to `CrtdlConsentValidatorTest` (pre-existing Docker Compose/container-contention sandbox flakiness, unrelated — passes 34/34 in isolation).
- [x] Black-box suites (`CdsBlackBoxIT`, `SpecificBlackBoxIT`) not executed (need a built `torch:latest` image + `blackbox-integration-tests` profile); static review of their fixtures found no profile with an unsatisfied required-slice scenario at risk.