### PR TITLE
Release v1.0.0-beta.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+## [v1.0.0-beta.6] - 2026-07-22
+
+### Fixed
+
+- Fix Shared FHIRPathEngine Race Under Concurrent parallelStream Evaluation [#1087](https://github.com/medizininformatik-initiative/torch/pull/1087)
+- Fix Job.initBatches resetting version to 0, breaking optimistic concurrency [#1054](https://github.com/medizininformatik-initiative/torch/pull/1054)
+- Fix CascadingDelete silently skipping must-have escalation for shared reference targets [#1047](https://github.com/medizininformatik-initiative/torch/pull/1047)
+- Fix CascadingDelete retaining reference-only cycles with no live anchor [#1043](https://github.com/medizininformatik-initiative/torch/pull/1043)
+- Log ConsentViolatedException message in ExtractDataService instead of silently swallowing it [#1030](https://github.com/medizininformatik-initiative/torch/pull/1030)
+
+
 ## [v1.0.0-beta.5] - 2026-06-26
 
 ### Fixed

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -178,17 +178,17 @@ For container images, we use cosign to sign images. This allows users to confirm
 pipeline and has not been modified after publication.
 
 ```
-cosign verify "ghcr.io/medizininformatik-initiative/torch:v1.0.0" \
+cosign verify "ghcr.io/medizininformatik-initiative/torch:v1.0.0-beta.6" \
 --certificate-identity-regexp "https://github.com/medizininformatik-initiative/torch.*" \
 --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
---certificate-github-workflow-ref="refs/tags/v1.0.0" \
+--certificate-github-workflow-ref="refs/tags/v1.0.0-beta.6" \
 -o text
 ```
 
 The expected output is:
 
 ```
-Verification for ghcr.io/medizininformatik-initiative/torch:v1.0.0 --
+Verification for ghcr.io/medizininformatik-initiative/torch:v1.0.0-beta.6 --
 The following checks were performed on each of these signatures:
 - The cosign claims were validated
 - Existence of the claims in the transparency log was verified offline
@@ -196,5 +196,5 @@ The following checks were performed on each of these signatures:
 ```
 
 This output ensures that the image was build on the GitHub workflow on the repository
-`medizininformatik-initiative/torch` and tag `v1.0.0`.
+`medizininformatik-initiative/torch` and tag `v1.0.0-beta.6`.
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>de.medizininformatikinitiative</groupId>
     <artifactId>torch</artifactId>
-    <version>v1.0.0-beta.5</version>
+    <version>v1.0.0-beta.6</version>
 
     <properties>
         <maven.compiler.source>21</maven.compiler.source>

--- a/src/main/java/de/medizininformatikinitiative/torch/rest/CapabilityStatementController.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/rest/CapabilityStatementController.java
@@ -52,7 +52,7 @@ public class CapabilityStatementController {
         capabilityStatement.setDate(new java.util.Date());
         capabilityStatement.setFhirVersion(Enumerations.FHIRVersion._4_0_1);
         capabilityStatement.setKind(CapabilityStatement.CapabilityStatementKind.INSTANCE);
-        capabilityStatement.getSoftware().setName("Torch FHIR Server").setVersion("1.0.0-beta.5");
+        capabilityStatement.getSoftware().setName("Torch FHIR Server").setVersion("1.0.0-beta.6");
         capabilityStatement.getImplementation().setDescription("Torch FHIR Server Implementation");
         logger.trace("Created basic metadata for CapabilityStatement");
 


### PR DESCRIPTION
## Summary
Release v1.0.0-beta.6, covering milestone [v1.0.0-beta.6](https://github.com/medizininformatik-initiative/torch/milestone/30):

- Fix Shared FHIRPathEngine Race Under Concurrent parallelStream Evaluation (#1087)
- Fix Job.initBatches resetting version to 0, breaking optimistic concurrency (#1054)
- Fix CascadingDelete silently skipping must-have escalation for shared reference targets (#1047)
- Fix CascadingDelete retaining reference-only cycles with no live anchor (#1043)
- Log ConsentViolatedException message in ExtractDataService instead of silently swallowing it (#1030)

## Test plan
- [ ] Review CHANGELOG.md entry
- [ ] Review pom.xml version bump