### PR TITLE
FHIR WebClient connection pool has no idle timeout

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -112,6 +112,14 @@ Maximum number of concurrent connections allowed to the FHIR server. Must be at 
 
 ---
 
+#### `TORCH_FHIR_MAX_IDLE_TIME_SECONDS` <Badge type="warning" text="Since 1.0.0-beta.7"/>
+
+Maximum time a pooled connection to the FHIR server may sit idle before it is evicted instead of reused. Keep this below the idle/keepalive timeout of any reverse proxy in front of the FHIR server to avoid `PrematureCloseException` from reusing a connection the proxy has already closed.
+
+**Default:** `30`
+
+---
+
 #### `TORCH_FHIR_PAGE_COUNT` <Badge type="warning" text="Since 1.0.0-alpha"/>
 
 Number of entries per page in FHIR search responses.
@@ -133,6 +141,14 @@ Set to `true` to disable the use of the Asynchronous Interaction Request Pattern
 Base URL of the FLARE server used in the pipeline.
 
 **Default:** – (none)
+
+---
+
+#### `TORCH_FLARE_MAX_IDLE_TIME_SECONDS` <Badge type="warning" text="Since 1.0.0-beta.7"/>
+
+Maximum time a pooled connection to the FLARE server may sit idle before it is evicted instead of reused. Keep this below the idle/keepalive timeout of any reverse proxy in front of the FLARE server to avoid `PrematureCloseException` from reusing a connection the proxy has already closed.
+
+**Default:** `30`
 
 ---
 

--- a/src/main/java/de/medizininformatikinitiative/torch/config/FhirProperties.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/config/FhirProperties.java
@@ -54,6 +54,7 @@ public record FhirProperties(
         }
     }
 
-    public record Max(@Min(value = 1, message = "Max connections must be at least 1") int connections) {
+    public record Max(@Min(value = 1, message = "Max connections must be at least 1") int connections,
+                       @Min(value = 1, message = "Max idle time must be at least 1 second") int idleTimeSeconds) {
     }
 }

--- a/src/main/java/de/medizininformatikinitiative/torch/config/TorchProperties.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/config/TorchProperties.java
@@ -68,11 +68,17 @@ public record TorchProperties(
     }
 
 
-    public record Flare(String url) {
+    public record Flare(String url, @Valid Max max) {
         public Flare {
             if (!ConfigUtils.isNotSet(url)) {
                 url = ConfigUtils.removeTrailingSlashes(url);
             }
+            if (max == null) {
+                max = new Max(30);
+            }
+        }
+
+        public record Max(@Min(value = 1, message = "Max idle time must be at least 1 second") int idleTimeSeconds) {
         }
     }
 

--- a/src/main/java/de/medizininformatikinitiative/torch/config/WebConfig.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/config/WebConfig.java
@@ -20,6 +20,7 @@ import reactor.netty.http.client.HttpClient;
 import reactor.netty.resources.ConnectionProvider;
 
 import java.time.Clock;
+import java.time.Duration;
 
 import static org.springframework.security.oauth2.core.AuthorizationGrantType.CLIENT_CREDENTIALS;
 import static org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames.REGISTRATION_ID;
@@ -30,17 +31,23 @@ public class WebConfig {
     private static final Logger logger = LoggerFactory.getLogger(WebConfig.class);
 
     @Bean
-    public ConnectionProvider flareConnectionProvider() {
+    public ConnectionProvider flareConnectionProvider(TorchProperties torchProperties) {
+        Duration maxIdleTime = Duration.ofSeconds(torchProperties.flare().max().idleTimeSeconds());
         return ConnectionProvider.builder("flare-pool")
                 .maxConnections(4)
                 .pendingAcquireMaxCount(500)
+                .maxIdleTime(maxIdleTime)
+                .evictInBackground(maxIdleTime)
                 .build();
     }
 
     @Bean
     public ConnectionProvider fhirConnectionProvider(FhirProperties fhirProperties) {
+        Duration maxIdleTime = Duration.ofSeconds(fhirProperties.max().idleTimeSeconds());
         return ConnectionProvider.builder("fhir-pool")
                 .maxConnections(fhirProperties.max().connections())
+                .maxIdleTime(maxIdleTime)
+                .evictInBackground(maxIdleTime)
                 .build();
     }
 

--- a/src/main/java/de/medizininformatikinitiative/torch/service/DataStore.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/service/DataStore.java
@@ -62,15 +62,16 @@ public class DataStore {
      * Retries:
      * - HTTP status based (5xx, 404, 429) via WebClientResponseException
      * - Transport problems like "prematurely closed connection" via WebClientRequestException causes
-     * Does try for 1h max at max 5min intervals (9 calls around 8min)
+     * Does try for ~1h max at max 5min intervals (9 calls around 8min, then capped at 5min each)
      */
-    private static final RetryBackoffSpec RETRY_SPEC = Retry.backoff(20, Duration.ofSeconds(1))
+    private static final int MAX_RETRY_ATTEMPTS = 20;
+    private static final RetryBackoffSpec RETRY_SPEC = Retry.backoff(MAX_RETRY_ATTEMPTS, Duration.ofSeconds(1))
             .maxBackoff(Duration.ofMinutes(5))
             .filter(RetryabilityUtil::isRetryable)
             .doBeforeRetry(rs -> logger.warn(
                     "Retrying DataStore call (attempt {} of {}) due to: {}",
                     rs.totalRetries() + 1,
-                    5,
+                    MAX_RETRY_ATTEMPTS,
                     RetryabilityUtil.rootCauseMessage(rs.failure())
             ));
     public static final String APPLICATION_FHIR_JSON = "application/fhir+json";

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,10 +26,13 @@ torch:
       count: 500
     max:
       connections: 5
+      idleTimeSeconds: 30
     disable:
       async: false
   flare:
     url:
+    max:
+      idleTimeSeconds: 30
   results:
     dir: output/
   batchsize: 500

--- a/src/test/java/de/medizininformatikinitiative/torch/config/FhirPropertiesTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/config/FhirPropertiesTest.java
@@ -14,7 +14,7 @@ class FhirPropertiesTest {
         void defaultsWhenUserPasswordAndOauthNull() {
             FhirProperties fhir = new FhirProperties(
                     "http://fhir-url",
-                    new FhirProperties.Max(5),
+                    new FhirProperties.Max(5, 30),
                     new FhirProperties.Page(10),
                     null, // oauth is null
                     new FhirProperties.Disable(true),
@@ -55,7 +55,7 @@ class FhirPropertiesTest {
         void stripsTrailingSlashes() {
             var fhir = new FhirProperties(
                     "http://fhir-url/////",
-                    new FhirProperties.Max(3),
+                    new FhirProperties.Max(3, 30),
                     new FhirProperties.Page(5),
                     null,
                     new FhirProperties.Disable(false),
@@ -70,7 +70,7 @@ class FhirPropertiesTest {
         void defaultOauthAndCredentials() {
             var fhir = new FhirProperties(
                     "http://fhir-url",
-                    new FhirProperties.Max(3),
+                    new FhirProperties.Max(3, 30),
                     new FhirProperties.Page(5),
                     null,
                     new FhirProperties.Disable(false),

--- a/src/test/java/de/medizininformatikinitiative/torch/config/FhirServerConnectivityCheckTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/config/FhirServerConnectivityCheckTest.java
@@ -14,7 +14,7 @@ class FhirServerConnectivityCheckTest {
     private FhirProperties fhirProperties(String url) {
         return new FhirProperties(
                 url,
-                new FhirProperties.Max(5),
+                new FhirProperties.Max(5, 30),
                 new FhirProperties.Page(10),
                 new FhirProperties.Oauth(new FhirProperties.Oauth.Issuer(""), new FhirProperties.Oauth.Client("", "")),
                 new FhirProperties.Disable(false),

--- a/src/test/java/de/medizininformatikinitiative/torch/config/TorchPropertiesTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/config/TorchPropertiesTest.java
@@ -39,7 +39,7 @@ public class TorchPropertiesTest {
 
         @Test
         void flareURLNullShouldThrow() {
-            var flare = new TorchProperties.Flare(null);
+            var flare = new TorchProperties.Flare(null, null);
 
             assertThatThrownBy(() -> new TorchProperties(
                     new TorchProperties.Base("http://base-url"),
@@ -62,7 +62,7 @@ public class TorchPropertiesTest {
 
         @Test
         void flareURLBlankShouldThrow() {
-            var flare = new TorchProperties.Flare("  ");
+            var flare = new TorchProperties.Flare("  ", null);
 
             assertThatThrownBy(() -> new TorchProperties(
                     new TorchProperties.Base("http://base-url"),
@@ -85,7 +85,7 @@ public class TorchPropertiesTest {
 
         @Test
         void flareURLSetPasses() {
-            var flare = new TorchProperties.Flare("http://flare-url");
+            var flare = new TorchProperties.Flare("http://flare-url", null);
 
             assertThatCode(() -> new TorchProperties(
                     new TorchProperties.Base("http://base-url"),
@@ -107,7 +107,7 @@ public class TorchPropertiesTest {
 
         @Test
         void flareIgnoredWithCQL() {
-            var flare = new TorchProperties.Flare(null);
+            var flare = new TorchProperties.Flare(null, null);
 
             assertThatCode(() -> new TorchProperties(
                     new TorchProperties.Base("http://base-url"),
@@ -158,7 +158,7 @@ public class TorchPropertiesTest {
         void defaultsWhenUserPasswordAndOauthNull() {
             FhirProperties fhir = new FhirProperties(
                     "http://fhir-url",
-                    new FhirProperties.Max(5),
+                    new FhirProperties.Max(5, 30),
                     new FhirProperties.Page(10),
                     null, // oauth is null
                     new FhirProperties.Disable(true),
@@ -199,7 +199,7 @@ public class TorchPropertiesTest {
         void defaultOauthAndCredentials() {
             var fhir = new FhirProperties(
                     "http://fhir-url",
-                    new FhirProperties.Max(3),
+                    new FhirProperties.Max(3, 30),
                     new FhirProperties.Page(5),
                     null,
                     new FhirProperties.Disable(false),

--- a/src/test/java/de/medizininformatikinitiative/torch/config/WebConfigTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/config/WebConfigTest.java
@@ -64,7 +64,7 @@ class WebConfigTest {
         var oauth = new FhirProperties.Oauth(oauthIssuer, oauthClient);
         return new FhirProperties(
                 url,
-                new FhirProperties.Max(5),
+                new FhirProperties.Max(5, 30),
                 page,
                 oauth,
                 new FhirProperties.Disable(false),
@@ -96,7 +96,7 @@ class WebConfigTest {
         var mapping = new TorchProperties.Mapping("type-to-consent.json");
 
 
-        var flare = new TorchProperties.Flare("http://flare-url");
+        var flare = new TorchProperties.Flare("http://flare-url", null);
         var results = new TorchProperties.Results("results-dir");
 
         return new TorchProperties(
@@ -124,7 +124,7 @@ class WebConfigTest {
         var oauth = new FhirProperties.Oauth(oauthIssuer, oauthClient);
         return new FhirProperties(
                 "http://localhost/fhir",
-                new FhirProperties.Max(5),
+                new FhirProperties.Max(5, 30),
                 page,
                 oauth,
                 new FhirProperties.Disable(false),

--- a/src/test/java/de/medizininformatikinitiative/torch/rest/FhirControllerTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/rest/FhirControllerTest.java
@@ -73,7 +73,7 @@ class FhirControllerTest {
             new TorchProperties.Output(new TorchProperties.Output.File(new TorchProperties.Output.File.Server("http://server-url"))),
             new TorchProperties.Profile("/profile-dir"),
             new TorchProperties.Mapping("typeToConsent"),
-            new TorchProperties.Flare(null),
+            new TorchProperties.Flare(null, null),
             new TorchProperties.Results("BASE_DIR"),
             10, 5, 100,
             "mappingsFile", "conceptTreeFile", "dseMappingTreeFile",

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -16,12 +16,15 @@ torch:
       count: 500
     max:
       connections: 4
+      idleTimeSeconds: 30
     disable:
       async: false
     testPopulation:
       path: src/test/resources/BlazeBundle.json
   flare:
     url:
+    max:
+      idleTimeSeconds: 30
   results:
     dir: output/
   batchsize: 2


### PR DESCRIPTION
## Summary
- Both `fhirConnectionProvider` and `flareConnectionProvider` now set `maxIdleTime`/`evictInBackground`, so pooled connections idle past a reverse-proxy's keepalive (e.g. nginx's default 75s) are evicted instead of reused, fixing `PrematureCloseException: Connection prematurely closed BEFORE response`.
- Idle time is configurable per pool with a 30s default: `torch.fhir.max.idleTimeSeconds` and `torch.flare.max.idleTimeSeconds`.
- Fixed the retry-attempt log in `DataStore` reporting the wrong max (`"attempt 11 of 5"`) by extracting the actual retry count (`20`) into a shared constant used by both the retry spec and the log message.

## Test plan
- [x] `mvn -o test-compile` — compiles cleanly
- [x] `WebConfigTest` (6/6), `TorchPropertiesTest` (14/14), `FhirPropertiesTest` (7/7), `FhirControllerTest` (31/31), `FhirServerConnectivityCheckTest` (3/3) — all pass
- [x] `WebConfigTest.shouldHaveFhirContextBean` boots the full Spring context with `WebConfig` active, confirming both connection providers wire up against the packaged `application.yml` defaults

Closes #1104