### PR TITLE
Investigate CPU-Bound FHIR Parsing Blocking Netty Event-Loop Threads in DataStore

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/torch/service/DataStore.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/service/DataStore.java
@@ -25,6 +25,7 @@ import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 import reactor.util.retry.Retry;
 import reactor.util.retry.RetryBackoffSpec;
 
@@ -132,6 +133,7 @@ public class DataStore {
                 .retrieve()
                 .bodyToMono(String.class)
                 .retryWhen(RETRY_SPEC)
+                .publishOn(Schedulers.boundedElastic())
                 .map(body -> fhirContext.newJsonParser().parseResource(Bundle.class, body))
                 .map(this::extractResourcesFromBundle)
                 .defaultIfEmpty(List.of())
@@ -189,6 +191,7 @@ public class DataStore {
                 .retrieve()
                 .bodyToMono(String.class)
                 .retryWhen(RETRY_SPEC) // retry first page
+                .publishOn(Schedulers.boundedElastic())
                 .map(body -> fhirContext.newJsonParser().parseResource(body))
                 .flatMap(resource -> {
                     if (resource instanceof Bundle bundle) {
@@ -239,6 +242,7 @@ public class DataStore {
                 .retrieve()
                 .bodyToMono(String.class)
                 .retryWhen(RETRY_SPEC) // retry this page only
+                .publishOn(Schedulers.boundedElastic())
                 .map(body ->
                         fhirContext.newJsonParser().parseResource(Bundle.class, body)
                 );
@@ -279,6 +283,7 @@ public class DataStore {
                 .retrieve()
                 .onStatus(status -> status.isSameCodeAs(ACCEPTED), response -> Mono.error(handleAcceptedResponse(response)))
                 .bodyToMono(String.class)
+                .publishOn(Schedulers.boundedElastic())
                 .flatMap(body -> parseResource(MeasureReport.class, body))
                 .onErrorResume(AsyncException.class, e -> pollStatus(e.getStatusUrl(), measureUrn, start))
                 .doOnSuccess(measureReport -> logger.debug("Successfully evaluated Measure with URN {} in {} seconds.",
@@ -304,6 +309,7 @@ public class DataStore {
                 })
                 .bodyToMono(String.class)
                 .retryWhen(ASYNC_POLL_SPEC)
+                .publishOn(Schedulers.boundedElastic())
                 .flatMap(body -> parseResource(Bundle.class, body))
                 .flatMap(bundle -> {
                     var entry = bundle.getEntryFirstRep();

--- a/src/test/java/de/medizininformatikinitiative/torch/service/DataStoreTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/service/DataStoreTest.java
@@ -31,7 +31,9 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static de.medizininformatikinitiative.torch.service.DataStoreIT.createBundleFromQuery;
 import static java.util.Objects.requireNonNull;
@@ -224,6 +226,45 @@ class DataStoreTest {
         }
 
         @Test
+        @DisplayName("parses first page off the Netty event-loop thread")
+        void firstPageParsedOffEventLoopThread() {
+            mockStore.enqueue(new MockResponse()
+                    .setResponseCode(200)
+                    .setHeader("Content-Type", "application/fhir+json")
+                    .setBody(PATIENT_BUNDLE));
+
+            var threadName = new AtomicReference<String>();
+            var result = dataStore.search(Query.ofType("Patient"), Patient.class)
+                    .doOnNext(resource -> threadName.set(Thread.currentThread().getName()));
+
+            StepVerifier.create(result).expectNextCount(1).verifyComplete();
+
+            assertThat(threadName.get()).startsWith("boundedElastic-");
+        }
+
+        @Test
+        @DisplayName("parses next page off the Netty event-loop thread")
+        void nextPageParsedOffEventLoopThread() {
+            String nextUrl = baseUrl + "/Patient?page=2";
+            mockStore.enqueue(new MockResponse()
+                    .setResponseCode(200)
+                    .setHeader("Content-Type", "application/fhir+json")
+                    .setBody(PATIENT_BUNDLE_WITH_NEXT.formatted(nextUrl)));
+            mockStore.enqueue(new MockResponse()
+                    .setResponseCode(200)
+                    .setHeader("Content-Type", "application/fhir+json")
+                    .setBody(PATIENT_BUNDLE_LAST_PAGE));
+
+            var threadNames = new CopyOnWriteArrayList<String>();
+            var result = dataStore.search(Query.ofType("Patient"), Patient.class)
+                    .doOnNext(resource -> threadNames.add(Thread.currentThread().getName()));
+
+            StepVerifier.create(result).expectNextCount(2).verifyComplete();
+
+            assertThat(threadNames.get(1)).startsWith("boundedElastic-");
+        }
+
+        @Test
         void operationOutcomeReturnsError() {
             mockStore.enqueue(new MockResponse()
                     .setResponseCode(200)
@@ -413,6 +454,22 @@ class DataStoreTest {
             StepVerifier.create(result).verifyError(WebClientResponseException.BadRequest.class);
         }
 
+        @Test
+        @DisplayName("parses batch bundle off the Netty event-loop thread")
+        void parsedOffEventLoopThread() {
+            mockStore.enqueue(new MockResponse()
+                    .setResponseCode(200)
+                    .setHeader("Content-Type", "application/fhir+json")
+                    .setBody(BATCH_RESPONSE));
+
+            var threadName = new AtomicReference<String>();
+            var result = dataStore.executeBundle(createBundleFromQuery("Patient?_id=1,2"))
+                    .doOnNext(resources -> threadName.set(Thread.currentThread().getName()));
+
+            StepVerifier.create(result).expectNextCount(1).verifyComplete();
+
+            assertThat(threadName.get()).startsWith("boundedElastic-");
+        }
 
     }
 
@@ -631,6 +688,20 @@ class DataStoreTest {
                         .expectNextMatches(resource -> resource.getResourceType() == MeasureReport)
                         .verifyComplete();
             }
+
+            @Test
+            @DisplayName("parses polled status bundle off the Netty event-loop thread")
+            void parsedOffEventLoopThread() {
+                mockStore.setDispatcher(dispatcher(responseSuccess, batchResponseSuccess, new AtomicInteger(0)));
+
+                var threadName = new AtomicReference<String>();
+                var result = dataStore.evaluateMeasure(params("uri-152349"))
+                        .doOnNext(resource -> threadName.set(Thread.currentThread().getName()));
+
+                StepVerifier.create(result).expectNextCount(1).verifyComplete();
+
+                assertThat(threadName.get()).startsWith("boundedElastic-");
+            }
         }
 
         @Nested
@@ -669,6 +740,20 @@ class DataStoreTest {
                 StepVerifier.create(result)
                         .expectNextMatches(resource -> resource.getResourceType() == MeasureReport)
                         .verifyComplete();
+            }
+
+            @Test
+            @DisplayName("parses measure report off the Netty event-loop thread")
+            void parsedOffEventLoopThread() {
+                mockStore.setDispatcher(dispatcher(responseSuccess, batchResponseSuccess));
+
+                var threadName = new AtomicReference<String>();
+                var result = dataStore.evaluateMeasure(params("uri-152349"))
+                        .doOnNext(resource -> threadName.set(Thread.currentThread().getName()));
+
+                StepVerifier.create(result).expectNextCount(1).verifyComplete();
+
+                assertThat(threadName.get()).startsWith("boundedElastic-");
             }
         }
     }


### PR DESCRIPTION
## Summary
- Adds `.publishOn(Schedulers.boundedElastic())` right after the network fetch (and after any `retryWhen`) at all four parsing sites in `DataStore`: `executeBundle`, `search` (first page), `fetchPage` (subsequent pages), and the shared `parseResource` helper's two call sites (`evaluateMeasure`, `pollStatus`). This moves the synchronous, potentially CPU-heavy FHIR JSON parse off the Netty event-loop thread that delivered the response, preventing it from starving other requests sharing that same small thread pool (e.g. the `__status` polling endpoint).
- Matches the existing precedent in `CohortQueryService.java` (`.bodyToMono(String.class).publishOn(Schedulers.boundedElastic()).flatMap(...)`), so this isn't a new pattern for the codebase.
- Applied uniformly to all four sites rather than only the two implicated in the reported trace (`search`/`fetchPage`), since all four perform the identical class of operation and the CLAUDE.md hard constraint calls for offloading this kind of work regardless of expected payload size.

**Scope note:** this issue is explicitly framed as *Investigate*, with root cause still unconfirmed between two candidates (heap exhaustion vs. Netty event-loop starvation) pending the reporting site's full trace. This change addresses only the event-loop-starvation candidate — if the actual cause turns out to be heap exhaustion, the hang could still recur, and that would need separate tuning of `torch.fhir.page.count`/`torch.maxconcurrency`, which the issue itself calls orthogonal to this change. Left the issue open (`Relates to #1105`) rather than closing it.

## Test plan
- [x] Added a thread-identity test per call site (`DataStoreTest`) capturing `Thread.currentThread().getName()` at the point resources are emitted from `DataStore`, using the real `WebClient` against `MockWebServer` (so the delivery thread is a genuine Netty event-loop thread, exactly like production).
- [x] **Reproduced first**: ran the new tests against the code *before* the fix — confirmed all five call sites parsed on a `reactor-http-epoll-*` thread, matching the exact mechanism described in the issue.
- [x] Applied the fix, reran the same tests — all now confirm `boundedElastic-*`.
- [x] Full `DataStoreTest` suite: 26/26 pass.
- [x] JaCoCo: all 5 new `.publishOn(...)` lines show 0 missed instructions.
- [x] Full unit test suite: 1171 tests, 0 failures. The 17 errors seen are the pre-existing `CrtdlConsentValidatorTest` Docker/Testcontainers resource-contention flakiness under full-suite load (confirmed unrelated by running that class in isolation, which passes cleanly).

Relates to #1105