### PR TITLE
Add INFO-Level Visibility Into Long-Running Cohort Queries And Job Wait Times

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/torch/jobhandling/JobScheduler.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/jobhandling/JobScheduler.java
@@ -4,7 +4,10 @@ package de.medizininformatikinitiative.torch.jobhandling;
 import de.medizininformatikinitiative.torch.config.TorchProperties;
 import de.medizininformatikinitiative.torch.exceptions.JobNotFoundException;
 import de.medizininformatikinitiative.torch.jobhandling.failure.RetryabilityUtil;
+import de.medizininformatikinitiative.torch.jobhandling.workunit.ProcessBatchWorkUnit;
+import de.medizininformatikinitiative.torch.jobhandling.workunit.ProcessCohortWorkUnit;
 import de.medizininformatikinitiative.torch.jobhandling.workunit.WorkUnit;
+import de.medizininformatikinitiative.torch.util.TimeUtils;
 import jakarta.annotation.PreDestroy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,6 +23,7 @@ import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Schedules and executes {@link WorkUnit}s using a fixed-size worker pool.
@@ -35,6 +39,7 @@ public class JobScheduler {
     private final ExecutorService executor;
     private final JobExecutionContext ctx;
     private volatile boolean running = false;
+    private final AtomicInteger activeWorkers = new AtomicInteger();
 
 
     static long RETRY_SLEEP_MS = 1000;
@@ -148,23 +153,41 @@ public class JobScheduler {
     }
 
     void executeBlocking(WorkUnit wu) throws IOException {
-        wu.execute(ctx)
-                .onErrorResume(JobNotFoundException.class, e -> Mono.empty())
-                .onErrorResume(t -> {
-                    if (RetryabilityUtil.isRetryable(t)) {
-                        logger.warn("Work unit for job {} failed (retryable): {}", wu.job().id(), RetryabilityUtil.rootCauseMessage(t));
-                    } else {
-                        logger.error("Work unit for job {} failed", wu.job().id(), t);
-                    }
-                    return Mono.fromCallable(() -> {
-                                ctx.persistence().onJobError(wu.job().id(), List.of(), t);
-                                return 0;
-                            })
-                            .subscribeOn(Schedulers.boundedElastic())
-                            .onErrorResume(JobNotFoundException.class, e -> Mono.empty())
-                            .then();
-                })
-                .block();
+        var start = System.nanoTime();
+        var phase = phaseOf(wu);
+        var jobId = wu.job().id();
+        int busy = activeWorkers.incrementAndGet();
+        logger.info("Starting {} for job {} ({}/{} workers busy)", phase, jobId, busy, maxConcurrency);
+        try {
+            wu.execute(ctx)
+                    .onErrorResume(JobNotFoundException.class, e -> Mono.empty())
+                    .onErrorResume(t -> {
+                        if (RetryabilityUtil.isRetryable(t)) {
+                            logger.warn("Work unit for job {} failed (retryable): {}", wu.job().id(), RetryabilityUtil.rootCauseMessage(t));
+                        } else {
+                            logger.error("Work unit for job {} failed", wu.job().id(), t);
+                        }
+                        return Mono.fromCallable(() -> {
+                                    ctx.persistence().onJobError(wu.job().id(), List.of(), t);
+                                    return 0;
+                                })
+                                .subscribeOn(Schedulers.boundedElastic())
+                                .onErrorResume(JobNotFoundException.class, e -> Mono.empty())
+                                .then();
+                    })
+                    .block();
+        } finally {
+            activeWorkers.decrementAndGet();
+            logger.info("Finished {} for job {} in {} seconds", phase, jobId,
+                    "%.1f".formatted(TimeUtils.durationSecondsSince(start)));
+        }
+    }
+
+    private static String phaseOf(WorkUnit wu) {
+        if (wu instanceof ProcessCohortWorkUnit) {
+            return "cohort query";
+        }
+        return wu instanceof ProcessBatchWorkUnit ? "batch processing" : "core processing";
     }
 
 }

--- a/src/main/java/de/medizininformatikinitiative/torch/service/DataStore.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/service/DataStore.java
@@ -269,7 +269,7 @@ public class DataStore {
     public Mono<MeasureReport> evaluateMeasure(Parameters params) {
         var start = System.nanoTime();
         var measureUrn = params.getParameter("measure").getValue().toString();
-        logger.debug("Evaluate Measure with URN {}...", measureUrn);
+        logger.info("Evaluate Measure with URN {}...", measureUrn);
 
         return client.post()
                 .uri("/Measure/$evaluate-measure")
@@ -281,7 +281,7 @@ public class DataStore {
                 .bodyToMono(String.class)
                 .flatMap(body -> parseResource(MeasureReport.class, body))
                 .onErrorResume(AsyncException.class, e -> pollStatus(e.getStatusUrl(), measureUrn, start))
-                .doOnSuccess(measureReport -> logger.debug("Successfully evaluated Measure with URN {} in {} seconds.",
+                .doOnSuccess(measureReport -> logger.info("Successfully evaluated Measure with URN {} in {} seconds.",
                         measureUrn, "%.1f".formatted(TimeUtils.durationSecondsSince(start))))
                 .doOnError(error -> logger.error("DATASTORE_04 Error occurred while evaluating Measure with URN {}: {}", measureUrn, error.getMessage()));
     }
@@ -298,7 +298,7 @@ public class DataStore {
         return client.get().uri(statusUrl)
                 .retrieve()
                 .onStatus(status -> status.isSameCodeAs(ACCEPTED) || RetryabilityUtil.shouldRetry(status), response -> {
-                    logger.trace("Evaluation of measure with URN {} is still in progress for {} seconds.",
+                    logger.info("Evaluation of measure with URN {} is still in progress for {} seconds.",
                             measureUrn, "%.1f".formatted(TimeUtils.durationSecondsSince(start)));
                     return Mono.error(new AsyncRetryException());
                 })

--- a/src/test/java/de/medizininformatikinitiative/torch/jobhandling/JobSchedulerTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/jobhandling/JobSchedulerTest.java
@@ -172,7 +172,10 @@ class JobSchedulerTest {
     void executeBlocking_ignoresDeletedJob() throws Exception {
         JobScheduler scheduler = newScheduler(newCtx());
         ProcessBatchWorkUnit mockWu = mock(ProcessBatchWorkUnit.class);
+        Job mockJob = mock(Job.class);
         UUID jobId = UUID.randomUUID();
+        when(mockWu.job()).thenReturn(mockJob);
+        when(mockJob.id()).thenReturn(jobId);
         when(mockWu.execute(any())).thenReturn(Mono.error(new JobNotFoundException(jobId)));
 
         Method executeBlocking = JobScheduler.class.getDeclaredMethod("executeBlocking", WorkUnit.class);


### PR DESCRIPTION
## Summary
- Promote three existing debug/trace log lines to `info` in `DataStore` (measure-evaluation start, success, and async-poll in-progress) so a long-running CQL cohort query is visible without enabling `debug`.
- Add `info`-level start/finish logging with duration and worker-pool occupancy (`X/maxConcurrency workers busy`) around `JobScheduler.executeBlocking`, covering all three work-unit phases (cohort query, batch processing, core processing), so operators can see what a job is doing and whether it's waiting for a worker slot.

Scoped to application logs only (not the diagnostics/`OperationOutcomeCreator` output, which #1069/#1089 are actively reworking) and to the CQL cohort path (Flare is out of scope), per discussion on #1111.

## Test plan
- [x] `mvn -Dtest=DataStoreTest test` — 15 tests, all passing
- [x] `mvn -Dtest=JobSchedulerTest test` — 14 tests, all passing (fixed one test's under-stubbed mock that the new eager `wu.job()` read exposed)

Closes #1111