### PR TITLE
Fix Reference Resolution Querying Wrong Resource Type For Polymorphic Linked References

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/torch/service/ReferenceResolver.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/service/ReferenceResolver.java
@@ -134,7 +134,7 @@ public class ReferenceResolver {
         return Flux.fromIterable(unresolvedRefsPerLinkedGroup.entrySet()).concatMap(e -> {
             var linkedGroupID = e.getKey();
             var unknownWrappers = e.getValue();
-            var unknownRefs = getRefsFromWrappers(unknownWrappers);
+            var unknownRefs = getRefsFromWrappers(unknownWrappers, groupMap.get(linkedGroupID));
 
             return bundleLoader.fetchUnknownResources(unknownRefs, linkedGroupID, groupMap)
                     .map(fetchedResources -> cacheNewCoreResources(fetchedResources, coreBundle))
@@ -309,8 +309,30 @@ public class ReferenceResolver {
         return newValidRGs.map(RGs -> Map.entry(patID, RGs));
     }
 
-    private List<ExtractionId> getRefsFromWrappers(List<ReferenceWrapper> wrappers) {
-        return wrappers.stream().flatMap(wrapper -> wrapper.references().stream()).toList();
+    /**
+     * Flattens the references of the given wrappers, keeping only those whose actual resource type (parsed from the
+     * reference itself) matches the linked group being fetched.
+     * <p>
+     * A single reference attribute can be polymorphic (e.g. {@code Encounter.diagnosis.condition} is
+     * {@code Reference(Condition|Procedure)}) and declare {@code linkedGroups} of different resource types. Without
+     * this filter, references would also be queried against linked groups of a type they can never match, wasting a
+     * FHIRSearch call and producing spurious "reference not loaded" warnings.
+     * <p>
+     * If {@code linkedGroup} is {@code null}, no reference can be matched to it, so an empty list is returned.
+     *
+     * @param wrappers    reference wrappers to flatten
+     * @param linkedGroup attribute group being fetched, or {@code null} if unknown
+     * @return references matching {@code linkedGroup}'s resource type
+     */
+    private List<ExtractionId> getRefsFromWrappers(List<ReferenceWrapper> wrappers, @Nullable AnnotatedAttributeGroup linkedGroup) {
+        if (linkedGroup == null) {
+            return List.of();
+        }
+        String linkedResourceType = linkedGroup.resourceType();
+        return wrappers.stream()
+                .flatMap(wrapper -> wrapper.references().stream())
+                .filter(ref -> ref.resourceType().equals(linkedResourceType))
+                .toList();
     }
 
     /**
@@ -372,7 +394,7 @@ public class ReferenceResolver {
         Flux<Map.Entry<String, Set<ResourceGroup>>> newRGsPerPat = Flux.fromIterable(unresolvedRefsPerLinkedGroup.entrySet()).concatMap(e -> {
             String linkedGroupID = e.getKey();
             List<ReferenceWrapper> unknownWrappers = e.getValue();
-            var unknownRefs = getRefsFromWrappers(unknownWrappers);
+            var unknownRefs = getRefsFromWrappers(unknownWrappers, groupMap.get(linkedGroupID));
             var refsToPat = refToPatHelper.get(linkedGroupID);
 
             return bundleLoader.fetchUnknownResources(unknownRefs, linkedGroupID, groupMap)

--- a/src/test/java/de/medizininformatikinitiative/torch/service/ReferenceResolverTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/service/ReferenceResolverTest.java
@@ -14,6 +14,7 @@ import de.medizininformatikinitiative.torch.model.management.ResourceBundle;
 import de.medizininformatikinitiative.torch.model.management.ResourceGroup;
 import de.medizininformatikinitiative.torch.util.ReferenceExtractor;
 import de.medizininformatikinitiative.torch.util.ReferenceHandler;
+import org.hl7.fhir.r4.model.Encounter;
 import org.hl7.fhir.r4.model.Observation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -32,10 +33,13 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -204,6 +208,106 @@ class ReferenceResolverTest {
 
             StepVerifier.create(resolver.resolveUnknownCoreRefs(Set.of(rg), coreBundle, Map.of(), BatchDiagnosticsAcc.noop()))
                     .verifyComplete();
+        }
+
+        @Test
+        void polymorphicReference_onlyFetchesMatchingResourceTypePerLinkedGroup() throws Exception {
+            var obs = (Observation) new Observation().setId("obs-1");
+            var coreBundle = new ResourceBundle();
+            coreBundle.put(obs);
+            var rg = new ResourceGroup(OBS_ID, GROUP_ID);
+            when(compartmentManager.isInCompartment(rg)).thenReturn(false);
+
+            // Encounter.diagnosis.condition is Reference(Condition|Procedure): one attribute, two linked groups
+            // of different resource types, but the extracted reference is only ever a Condition.
+            var attr = new AnnotatedAttribute("Encounter.diagnosis.condition", "Encounter.diagnosis.condition", false,
+                    List.of("procGroup", "condGroup"));
+            var wrapper = new ReferenceWrapper(attr, List.of(COND_ID), GROUP_ID, OBS_ID);
+            when(referenceExtractor.extract(any(), anyMap(), anyString())).thenReturn(List.of(wrapper));
+
+            var procGroup = new AnnotatedAttributeGroup("procGroup", "Procedure", "http://example.org/Procedure", List.of(), List.of());
+            var condGroup = new AnnotatedAttributeGroup("condGroup", "Condition", "http://example.org/Condition", List.of(), List.of());
+            var groupMap = Map.of("procGroup", procGroup, "condGroup", condGroup);
+
+            // Server can't find the Condition either, so we can observe how each linked group reacts
+            // to a missing reference instead of only checking what was requested.
+            when(bundleLoader.fetchUnknownResources(anyList(), anyString(), anyMap())).thenReturn(Mono.just(List.of()));
+            when(referenceHandler.handleReferences(anyList(), isNull(), any(), anyMap(), anySet())).thenReturn(Flux.empty());
+
+            var acc = new BatchDiagnosticsAcc(UUID.randomUUID(), UUID.randomUUID(), 1);
+
+            StepVerifier.create(resolver.resolveUnknownCoreRefs(Set.of(rg), coreBundle, groupMap, acc))
+                    .verifyComplete();
+
+            // No FHIRSearch is wasted querying procGroup for a reference it can never match.
+            verify(bundleLoader).fetchUnknownResources(eq(List.of(COND_ID)), eq("condGroup"), anyMap());
+            verify(bundleLoader).fetchUnknownResources(eq(List.of()), eq("procGroup"), anyMap());
+
+            // The missing reference is attributed to the linked group whose type it actually matches...
+            assertThat(coreBundle.isValidResourceGroup(new ResourceGroup(COND_ID, "condGroup"))).isFalse();
+            // ...and never even considered under the linked group of the wrong type.
+            assertThat(coreBundle.contains(new ResourceGroup(COND_ID, "procGroup"))).isFalse();
+
+            // Counted once (under condGroup), not twice as it was before the fix, when procGroup was
+            // also queried for a Condition reference it could never resolve.
+            var snapshot = acc.snapshot(0);
+            assertThat(snapshot.countsFor(CriterionKeys.referenceNotFound("Condition")).orElseThrow().resourcesExcluded())
+                    .isEqualTo(1);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // resolveUnknownPatientBatchRefs
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class ResolveUnknownPatientBatchRefs {
+
+        @Test
+        void polymorphicReference_onlyFetchesMatchingResourceTypePerLinkedGroup() throws Exception {
+            var encId = new ExtractionId("Encounter", "enc-1");
+            var enc = new Encounter().setId("enc-1");
+            var prb = new PatientResourceBundle("p1");
+            prb.bundle().put(enc);
+            var batch = PatientBatchWithConsent.fromList(List.of(prb));
+            var rg = new ResourceGroup(encId, GROUP_ID);
+            when(compartmentManager.isInCompartment(rg)).thenReturn(true);
+
+            // Encounter.diagnosis.condition is Reference(Condition|Procedure): one attribute, two linked groups
+            // of different resource types, but the extracted reference is only ever a Condition.
+            var attr = new AnnotatedAttribute("Encounter.diagnosis.condition", "Encounter.diagnosis.condition", false,
+                    List.of("procGroup", "condGroup"));
+            var wrapper = new ReferenceWrapper(attr, List.of(COND_ID), GROUP_ID, encId);
+            when(referenceExtractor.extract(any(), anyMap(), anyString())).thenReturn(List.of(wrapper));
+
+            var procGroup = new AnnotatedAttributeGroup("procGroup", "Procedure", "http://example.org/Procedure", List.of(), List.of());
+            var condGroup = new AnnotatedAttributeGroup("condGroup", "Condition", "http://example.org/Condition", List.of(), List.of());
+            var groupMap = Map.of("procGroup", procGroup, "condGroup", condGroup);
+
+            // Server can't find the Condition either, so we can observe how each linked group reacts
+            // to a missing reference instead of only checking what was requested.
+            when(bundleLoader.fetchUnknownResources(anyList(), anyString(), anyMap())).thenReturn(Mono.just(List.of()));
+            when(referenceHandler.handleReferences(anyList(), any(), any(), anyMap(), anySet())).thenReturn(Flux.empty());
+
+            var acc = new BatchDiagnosticsAcc(UUID.randomUUID(), UUID.randomUUID(), 1);
+
+            StepVerifier.create(resolver.resolveUnknownPatientBatchRefs(Map.of("p1", Set.of(rg)), batch, groupMap, acc))
+                    .verifyComplete();
+
+            // No FHIRSearch is wasted querying procGroup for a reference it can never match.
+            verify(bundleLoader).fetchUnknownResources(eq(List.of(COND_ID)), eq("condGroup"), anyMap());
+            verify(bundleLoader).fetchUnknownResources(eq(List.of()), eq("procGroup"), anyMap());
+
+            // The missing reference is attributed to the linked group whose type it actually matches...
+            assertThat(prb.bundle().isValidResourceGroup(new ResourceGroup(COND_ID, "condGroup"))).isFalse();
+            // ...and never even considered under the linked group of the wrong type.
+            assertThat(prb.bundle().contains(new ResourceGroup(COND_ID, "procGroup"))).isFalse();
+
+            // Counted once (under condGroup), not twice as it was before the fix, when procGroup was
+            // also queried for a Condition reference it could never resolve.
+            var snapshot = acc.snapshot(0);
+            assertThat(snapshot.countsFor(CriterionKeys.referenceNotFound("Condition")).orElseThrow().resourcesExcluded())
+                    .isEqualTo(1);
         }
     }
 


### PR DESCRIPTION
## Summary
- `ReferenceResolver.getRefsFromWrappers` now filters each linked group's reference list down to the `ExtractionId`s whose `resourceType()` matches that linked group's `resourceType()` before fetching, instead of fanning every reference out across all declared `linkedGroups`.
- Fixes polymorphic reference attributes (e.g. `Encounter.diagnosis.condition`, `Reference(Condition|Procedure)`) sending guaranteed-empty FHIR search queries and logging spurious `Some references were not loaded` WARNs for resources that actually resolve correctly under their matching linked group.
- `ProfileMustHaveChecker.fulfilled()` still independently validates group membership via `meta.profile` regardless of how a resource entered the bundle, so no existing correctness check is relaxed.

## Note
As a side effect, this also removes a spurious `referenceNotFound` diagnostics exclusion count that was previously double-counted for the wrong-typed linked group. Flagging in case this affects diagnostics/logging work in flight elsewhere (#1111 / #1069 / #1089).

## Test plan
- [x] `ReferenceResolverTest` (14/14 pass), including two new regression tests covering `resolveUnknownCoreRefs` and `resolveUnknownPatientBatchRefs`
- [x] Confirmed both new tests fail against the pre-fix code and pass with the fix
- [x] Related suites unaffected: `ReferenceHandlerTest`, `CascadingDeleteTest`, `ReferenceBundleLoaderTest` (all pass)

Closes #1120