### PR TITLE
Release v1.0.0-beta.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+## [v1.0.0-beta.7] - 2026-07-27
+
+### Added
+
+- Add INFO-Level Visibility Into Long-Running Cohort Queries And Job Wait Times [#1119](https://github.com/medizininformatik-initiative/torch/pull/1119)
+- Support Deactivation Of Consent Calculation [#1131](https://github.com/medizininformatik-initiative/torch/pull/1131)
+
+### Changed
+
+- Update hapi to v8.10.1 [#1118](https://github.com/medizininformatik-initiative/torch/pull/1118)
+- Parameterize Torch Service Environment Variables In docker-compose.yml [#1128](https://github.com/medizininformatik-initiative/torch/pull/1128)
+
+### Fixed
+
+- Fix Extension Slices Missing URL Filter in Generated FHIRPath [#1108](https://github.com/medizininformatik-initiative/torch/pull/1108)
+- FHIR WebClient connection pool has no idle timeout [#1107](https://github.com/medizininformatik-initiative/torch/pull/1107)
+- Fix Reference Resolution Querying Wrong Resource Type For Polymorphic Linked References [#1121](https://github.com/medizininformatik-initiative/torch/pull/1121)
+- Omit Empty FHIR Elements Left By Partial Attribute Copies [#1137](https://github.com/medizininformatik-initiative/torch/pull/1137)
+
+### Documentation
+
+- Improve TASK API Documentation [#1117](https://github.com/medizininformatik-initiative/torch/pull/1117)
+
+
 ## [v1.0.0-beta.6] - 2026-07-22
 
 ### Fixed

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -178,17 +178,17 @@ For container images, we use cosign to sign images. This allows users to confirm
 pipeline and has not been modified after publication.
 
 ```
-cosign verify "ghcr.io/medizininformatik-initiative/torch:v1.0.0-beta.6" \
+cosign verify "ghcr.io/medizininformatik-initiative/torch:v1.0.0-beta.7" \
 --certificate-identity-regexp "https://github.com/medizininformatik-initiative/torch.*" \
 --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
---certificate-github-workflow-ref="refs/tags/v1.0.0-beta.6" \
+--certificate-github-workflow-ref="refs/tags/v1.0.0-beta.7" \
 -o text
 ```
 
 The expected output is:
 
 ```
-Verification for ghcr.io/medizininformatik-initiative/torch:v1.0.0-beta.6 --
+Verification for ghcr.io/medizininformatik-initiative/torch:v1.0.0-beta.7 --
 The following checks were performed on each of these signatures:
 - The cosign claims were validated
 - Existence of the claims in the transparency log was verified offline
@@ -196,5 +196,5 @@ The following checks were performed on each of these signatures:
 ```
 
 This output ensures that the image was build on the GitHub workflow on the repository
-`medizininformatik-initiative/torch` and tag `v1.0.0-beta.6`.
+`medizininformatik-initiative/torch` and tag `v1.0.0-beta.7`.
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>de.medizininformatikinitiative</groupId>
     <artifactId>torch</artifactId>
-    <version>v1.0.0-beta.6</version>
+    <version>v1.0.0-beta.7</version>
 
     <properties>
         <maven.compiler.source>21</maven.compiler.source>

--- a/src/main/java/de/medizininformatikinitiative/torch/rest/CapabilityStatementController.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/rest/CapabilityStatementController.java
@@ -52,7 +52,7 @@ public class CapabilityStatementController {
         capabilityStatement.setDate(new java.util.Date());
         capabilityStatement.setFhirVersion(Enumerations.FHIRVersion._4_0_1);
         capabilityStatement.setKind(CapabilityStatement.CapabilityStatementKind.INSTANCE);
-        capabilityStatement.getSoftware().setName("Torch FHIR Server").setVersion("1.0.0-beta.6");
+        capabilityStatement.getSoftware().setName("Torch FHIR Server").setVersion("1.0.0-beta.7");
         capabilityStatement.getImplementation().setDescription("Torch FHIR Server Implementation");
         logger.trace("Created basic metadata for CapabilityStatement");
 


### PR DESCRIPTION
## Summary
Release v1.0.0-beta.7:

- Add INFO-Level Visibility Into Long-Running Cohort Queries And Job Wait Times (#1119)
- Update hapi to v8.10.1 (#1118)
- Fix Extension Slices Missing URL Filter in Generated FHIRPath (#1108)
- FHIR WebClient connection pool has no idle timeout (#1107)
- Improve TASK API Documentation (#1117)
- Fix Reference Resolution Querying Wrong Resource Type For Polymorphic Linked References (#1121)
- Parameterize Torch Service Environment Variables In docker-compose.yml (#1128)
- Support Deactivation Of Consent Calculation (#1131)
- Omit Empty FHIR Elements Left By Partial Attribute Copies (#1137)

Also includes CI/dependency-only bumps not called out in the CHANGELOG: #1129, #1132, #1133.

Note: #1137's CHANGELOG line is included ahead of merge (approved, green, queued), but its code isn't cherry-picked into this branch — it'll arrive through the normal main rebase once the queue merges it.

## Test plan
- [ ] Review CHANGELOG.md entry
- [ ] Review pom.xml version bump