### PR TITLE
Parameterize Torch Service Environment Variables In docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,20 +46,20 @@ services:
       - ${PORT_TORCH:-127.0.0.1:8086}:8080
     environment:
       SERVER_PORT: 8080
-      TORCH_PROFILE_DIR: /app/ontology/structureDefinitions
-      TORCH_MAPPING_CONSENT: /app/mappings/consent-mappings_fhir.json # deprecated: combined consents are no longer supported
-      TORCH_MAPPING_TYPE_TO_CONSENT: /app/mappings/type_to_consent.json
-      TORCH_FHIR_URL: http://torch-data-store:8080/fhir
-      TORCH_FLARE_URL: http://torch-flare:8080
-      TORCH_RESULTS_DIR: /app/output
-      LOG_LEVEL: debug
-      TORCH_BASE_URL: http://localhost:8080
-      TORCH_OUTPUT_FILE_SERVER_URL: http://localhost:8085
-      TORCH_BATCHSIZE: 100
-      TORCH_MAXCONCURRENCY: 4
-      TORCH_MAPPINGSFILE: /app/ontology/mapping_cql.json
-      TORCH_CONCEPTTREEFILE: /app/ontology/mapping_tree.json
-      TORCH_USECQL: false
+      TORCH_PROFILE_DIR: ${TORCH_PROFILE_DIR:-/app/ontology/structureDefinitions}
+      TORCH_MAPPING_CONSENT: ${TORCH_MAPPING_CONSENT:-/app/mappings/consent-mappings_fhir.json} # deprecated: combined consents are no longer supported
+      TORCH_MAPPING_TYPE_TO_CONSENT: ${TORCH_MAPPING_TYPE_TO_CONSENT:-/app/mappings/type_to_consent.json}
+      TORCH_FHIR_URL: ${TORCH_FHIR_URL:-http://torch-data-store:8080/fhir}
+      TORCH_FLARE_URL: ${TORCH_FLARE_URL:-http://torch-flare:8080}
+      TORCH_RESULTS_DIR: ${TORCH_RESULTS_DIR:-/app/output}
+      LOG_LEVEL: ${TORCH_LOG_LEVEL:-debug}
+      TORCH_BASE_URL: ${TORCH_BASE_URL:-http://localhost:8080}
+      TORCH_OUTPUT_FILE_SERVER_URL: ${TORCH_OUTPUT_FILE_SERVER_URL:-http://localhost:8085}
+      TORCH_BATCHSIZE: ${TORCH_BATCHSIZE:-100}
+      TORCH_MAXCONCURRENCY: ${TORCH_MAXCONCURRENCY:-4}
+      TORCH_MAPPINGSFILE: ${TORCH_MAPPINGSFILE:-/app/ontology/mapping_cql.json}
+      TORCH_CONCEPTTREEFILE: ${TORCH_CONCEPTTREEFILE:-/app/ontology/mapping_tree.json}
+      TORCH_USECQL: ${TORCH_USECQL:-false}
 
     volumes:
       - "torch-data-store:/app/output"   # Shared volume with torch-nginx


### PR DESCRIPTION
## Summary
- The `torch` service in `docker-compose.yml` hardcoded every environment value, unlike `torch-data-store` and `torch-flare` which parameterize theirs with `${VAR:-default}`
- All `torch` env vars are now overridable the same way (e.g. `LOG_LEVEL: ${TORCH_LOG_LEVEL:-debug}`, `TORCH_BATCHSIZE: ${TORCH_BATCHSIZE:-100}`), with defaults unchanged
- `SERVER_PORT` is deliberately left hardcoded: the `ports:` mapping hardcodes the container-side target to `8080`, so making `SERVER_PORT` overridable without also updating that mapping would let it drift out of sync and break connectivity

Closes #1127

## Test plan
- [x] `docker compose config` — confirms defaults resolve unchanged
- [x] `TORCH_LOG_LEVEL=trace TORCH_BATCHSIZE=250 docker compose config` — confirms overrides apply correctly and don't leak into other services