### PR TITLE
Support Deactivation Of Consent Calculation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,7 @@ services:
       TORCH_MAPPINGSFILE: ${TORCH_MAPPINGSFILE:-/app/ontology/mapping_cql.json}
       TORCH_CONCEPTTREEFILE: ${TORCH_CONCEPTTREEFILE:-/app/ontology/mapping_tree.json}
       TORCH_USECQL: ${TORCH_USECQL:-false}
+      DISABLE_CONSENT_CALCULATION: ${TORCH_DISABLE_CONSENT_CALCULATION:-false}
 
     volumes:
       - "torch-data-store:/app/output"   # Shared volume with torch-nginx

--- a/src/main/java/de/medizininformatikinitiative/torch/config/TorchProperties.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/config/TorchProperties.java
@@ -23,7 +23,8 @@ public record TorchProperties(
         @NotBlank(message = "Concept tree file path is required") String conceptTreeFile,
         @NotBlank(message = "DSE mapping tree file path is required") String dseMappingTreeFile,
         @NotBlank(message = "Search Parameters file is required") String searchParametersFile,
-        boolean useCql
+        boolean useCql,
+        boolean disableConsentCalculation
 ) {
 
     public TorchProperties {

--- a/src/main/java/de/medizininformatikinitiative/torch/service/ExtractDataService.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/service/ExtractDataService.java
@@ -1,5 +1,6 @@
 package de.medizininformatikinitiative.torch.service;
 
+import de.medizininformatikinitiative.torch.config.TorchProperties;
 import de.medizininformatikinitiative.torch.consent.ConsentHandler;
 import de.medizininformatikinitiative.torch.diagnostics.BatchDiagnostics;
 import de.medizininformatikinitiative.torch.diagnostics.BatchDiagnosticsAcc;
@@ -72,6 +73,7 @@ public class ExtractDataService {
     private final PatientBatchToCoreBundleWriter batchToCoreWriter;
     private final DataStore dataStore;
     private final PostCascadeMustHaveChecker postCascadeMustHaveChecker;
+    private final TorchProperties torchProperties;
 
     public ExtractDataService(ResultFileManager resultFileManager,
                               ProcessedGroupFactory processedGroupFactory,
@@ -82,7 +84,8 @@ public class ExtractDataService {
                               PatientBatchToCoreBundleWriter writer,
                               ConsentHandler consentHandler,
                               DataStore dataStore,
-                              PostCascadeMustHaveChecker postCascadeMustHaveChecker) {
+                              PostCascadeMustHaveChecker postCascadeMustHaveChecker,
+                              TorchProperties torchProperties) {
         this.resultFileManager = requireNonNull(resultFileManager);
         this.processedGroupFactory = requireNonNull(processedGroupFactory);
         this.directResourceLoader = requireNonNull(directResourceLoader);
@@ -93,6 +96,7 @@ public class ExtractDataService {
         this.consentHandler = requireNonNull(consentHandler);
         this.dataStore = requireNonNull(dataStore);
         this.postCascadeMustHaveChecker = requireNonNull(postCascadeMustHaveChecker);
+        this.torchProperties = requireNonNull(torchProperties);
     }
 
     private static void logMemory(UUID id) {
@@ -118,6 +122,9 @@ public class ExtractDataService {
      * <p>If consent resolution raises {@link ConsentViolatedException}, the batch is converted
      * into a skipped result with diagnostics and a warning issue. Any other error bubbles up.
      *
+     * <p>If {@code torch.disableConsentCalculation} is set, consent resolution is skipped entirely
+     * and every patient in the batch is treated as fully consented.
+     *
      * @param selection identifies the job and batch to process
      * @return mono emitting the resulting {@link BatchResult}, or an error
      */
@@ -131,10 +138,13 @@ public class ExtractDataService {
         BatchDiagnosticsAcc acc = new BatchDiagnosticsAcc(jobId, batch.batchId(), batch.ids().size());
         long consentStart = System.nanoTime();
 
+        Mono<PatientBatchWithConsent> unconsented = Mono.just(PatientBatchWithConsent.fromBatch(batch));
         Mono<PatientBatchWithConsent> batchWithConsent =
-                crtdl.consentCodes()
-                        .map(code -> consentHandler.fetchAndBuildConsentInfo(code, batch))
-                        .orElse(Mono.just(PatientBatchWithConsent.fromBatch(batch)))
+                (torchProperties.disableConsentCalculation()
+                        ? unconsented
+                        : crtdl.consentCodes()
+                                .map(code -> consentHandler.fetchAndBuildConsentInfo(code, batch))
+                                .orElse(unconsented))
                         .doOnNext(bwc -> acc.recordStage(PipelineStage.CONSENT_FETCH,
                                 System.nanoTime() - consentStart, bwc.patientIds().size()))
                         .onErrorResume(ConsentViolatedException.class, ex -> {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,6 +42,7 @@ torch:
   dseMappingTreeFile: ontology/dse_mapping_tree.json
   useCql: true
   bufferSize: 100
+  disableConsentCalculation: ${DISABLE_CONSENT_CALCULATION:false}
   output:
     file:
       server:

--- a/src/test/java/de/medizininformatikinitiative/torch/config/TorchPropertiesTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/config/TorchPropertiesTest.java
@@ -32,7 +32,8 @@ public class TorchPropertiesTest {
                     "conceptTreeFile",
                     "dseMappingTreeFile",
                     "search-parameters.json",
-                    false // useCql=false
+                    false, // useCql=false
+                    false
             )).isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("When useCql is false, flare.url must be a non-empty string");
         }
@@ -55,6 +56,7 @@ public class TorchPropertiesTest {
                     "conceptTreeFile",
                     "dseMappingTreeFile",
                     "search-parameters.json",
+                    false,
                     false
             )).isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("When useCql is false, flare.url must be a non-empty string");
@@ -78,6 +80,7 @@ public class TorchPropertiesTest {
                     "conceptTreeFile",
                     "dseMappingTreeFile",
                     "search-parameters.json",
+                    false,
                     false
             )).isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("When useCql is false, flare.url must be a non-empty string");
@@ -101,6 +104,7 @@ public class TorchPropertiesTest {
                     "conceptTreeFile",
                     "dseMappingTreeFile",
                     "search-parameters.json",
+                    false,
                     false
             )).doesNotThrowAnyException();
         }
@@ -123,7 +127,8 @@ public class TorchPropertiesTest {
                     "conceptTreeFile",
                     "dseMappingTreeFile",
                     "search-parameters.json",
-                    true
+                    true,
+                    false
             )).doesNotThrowAnyException();
         }
 

--- a/src/test/java/de/medizininformatikinitiative/torch/config/WebConfigTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/config/WebConfigTest.java
@@ -113,7 +113,8 @@ class WebConfigTest {
                 "conceptTree.json",
                 "dseMappingTree.json",
                 "search-parameters.json",
-                false // useCql
+                false, // useCql
+                false // disableConsentCalculation
         );
     }
 

--- a/src/test/java/de/medizininformatikinitiative/torch/rest/FhirControllerTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/rest/FhirControllerTest.java
@@ -78,7 +78,8 @@ class FhirControllerTest {
             10, 5, 100,
             "mappingsFile", "conceptTreeFile", "dseMappingTreeFile",
             "search-parameters.json",
-            true
+            true,
+            false
     );
 
     WebTestClient client;

--- a/src/test/java/de/medizininformatikinitiative/torch/service/ExtractDataServiceTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/service/ExtractDataServiceTest.java
@@ -1,5 +1,6 @@
 package de.medizininformatikinitiative.torch.service;
 
+import de.medizininformatikinitiative.torch.config.TorchProperties;
 import de.medizininformatikinitiative.torch.consent.ConsentHandler;
 import de.medizininformatikinitiative.torch.exceptions.ConsentViolatedException;
 import de.medizininformatikinitiative.torch.exceptions.MustHaveViolatedException;
@@ -52,6 +53,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -82,6 +84,8 @@ class ExtractDataServiceTest {
     DataStore dataStore;
     @Mock
     PostCascadeMustHaveChecker postCascadeMustHaveChecker;
+    @Mock
+    TorchProperties torchProperties;
 
     ExtractDataService service;
     ExtractDataService spyService;
@@ -117,7 +121,8 @@ class ExtractDataServiceTest {
                 batchToCoreWriter,
                 consentHandler,
                 dataStore,
-                postCascadeMustHaveChecker
+                postCascadeMustHaveChecker,
+                torchProperties
         );
         spyService = Mockito.spy(service);
     }
@@ -265,6 +270,74 @@ class ExtractDataServiceTest {
                 mocked.verify(() -> ExtractionPatientBatch.of(any()));
 
                 verify(consentHandler).fetchAndBuildConsentInfo(Set.of(termcode), rawBatch);
+            }
+        }
+
+        @Test
+        void processBatch_whenDisableConsentCalculationTrue_skipsConsentHandlerEvenWithConsentCodes() {
+            UUID jobId = UUID.randomUUID();
+            UUID batchId = UUID.randomUUID();
+
+            // Mock crtdl to have consent codes, to prove the flag overrides their presence.
+            // Stub is lenient because the disabled branch never even reads consentCodes().
+            AnnotatedCrtdl crtdl = mock(AnnotatedCrtdl.class);
+            TermCode termcode = new TermCode("sys", "val");
+            lenient().when(crtdl.consentCodes()).thenReturn(Optional.of(Set.of(termcode)));
+
+            JobParameters params = mock(JobParameters.class);
+            when(params.crtdl()).thenReturn(crtdl);
+
+            Job job = jobWithParameters(jobId, JobStatus.PENDING, params);
+
+            GroupsToProcess groups = mock(GroupsToProcess.class);
+            when(processedGroupFactory.create(crtdl)).thenReturn(groups);
+            when(groups.directPatientCompartmentGroups()).thenReturn(List.of());
+            when(groups.allGroups()).thenReturn(Map.of());
+
+            PatientBatch rawBatch = mock(PatientBatch.class);
+            when(rawBatch.batchId()).thenReturn(batchId);
+            when(rawBatch.ids()).thenReturn(List.of());
+
+            BatchState batchState = mock(BatchState.class);
+            BatchState finishedState = mock(BatchState.class);
+            when(batchState.finishNow(WorkUnitStatus.FINISHED)).thenReturn(finishedState);
+
+            BatchSelection selection = mock(BatchSelection.class);
+            when(selection.job()).thenReturn(job);
+            when(selection.batchState()).thenReturn(batchState);
+            when(selection.batch()).thenReturn(rawBatch);
+
+            when(torchProperties.disableConsentCalculation()).thenReturn(true);
+
+            PatientBatchWithConsent bwc = mock(PatientBatchWithConsent.class);
+            when(bwc.keep(any())).thenReturn(bwc);
+
+            when(directResourceLoader.directLoadPatientCompartment(anyList(), any(), any()))
+                    .thenReturn(Mono.just(bwc));
+            when(referenceResolver.resolvePatientBatch(eq(bwc), anyMap(), any()))
+                    .thenReturn(Mono.just(bwc));
+            when(cascadingDelete.handlePatientBatch(eq(bwc), anyMap()))
+                    .thenReturn(bwc);
+
+            ExtractionPatientBatch ofResult = mock(ExtractionPatientBatch.class);
+            try (MockedStatic<ExtractionPatientBatch> mocked = mockStatic(ExtractionPatientBatch.class)) {
+                mocked.when(() -> ExtractionPatientBatch.of(any()))
+                        .thenReturn(ofResult);
+
+                ExtractionPatientBatch extracted = mock(ExtractionPatientBatch.class);
+                when(batchCopierRedacter.transformBatch(eq(ofResult), anyMap()))
+                        .thenReturn(extracted);
+
+                ExtractionResourceBundle coreBundle = mock(ExtractionResourceBundle.class);
+                when(batchToCoreWriter.toCoreBundle(extracted)).thenReturn(coreBundle);
+
+                doReturn(Mono.empty()).when(spyService).writeBatch(eq(jobId.toString()), eq(extracted));
+
+                StepVerifier.create(spyService.processBatch(selection))
+                        .assertNext(res -> assertThat(res.batchState()).isSameAs(finishedState))
+                        .verifyComplete();
+
+                verifyNoInteractions(consentHandler);
             }
         }
 


### PR DESCRIPTION
## Summary
- Add `DISABLE_CONSENT_CALCULATION` env var (`torch.disableConsentCalculation`, default `false`)
- When enabled, `ExtractDataService.processBatch` skips consent resolution entirely and treats every patient as fully consented, regardless of whether the CRTDL has a consent block
- Parameterized in `docker-compose.yml` via `TORCH_DISABLE_CONSENT_CALCULATION`, matching the #1127 pattern

## Test plan
- [x] `ExtractDataServiceTest` — new test asserts `ConsentHandler` is never invoked when the flag is true, even with consent codes present in the CRTDL
- [x] `TorchPropertiesTest`, `WebConfigTest`, `FhirControllerTest` updated for the new constructor/record argument and pass

Closes #1130