### PR TITLE
Omit Empty FHIR Elements Left By Partial Attribute Copies

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/torch/util/ElementCopier.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/util/ElementCopier.java
@@ -69,8 +69,10 @@ public class ElementCopier {
                 }
             }
 
-            // Set the field on the target reflectively
-            CopyUtils.setFieldReflectively(tgt, fieldName, processed.values().stream().toList());
+            // Set the field on the target reflectively, dropping instances left empty because none of the
+            // requested sub-elements matched (an absent field is handled correctly downstream by Redaction,
+            // whereas an empty element violates the FHIR ele-1 invariant)
+            CopyUtils.setFieldReflectively(tgt, fieldName, processed.values().stream().filter(base -> !base.isEmpty()).toList());
         }
     }
 

--- a/src/test/java/de/medizininformatikinitiative/torch/util/ElementCopierTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/util/ElementCopierTest.java
@@ -79,10 +79,33 @@ class ElementCopierTest {
                 .setType(new CodeableConcept().addCoding(new Coding().setCode("official"))));
         expected.addIdentifier(new Identifier()
                 .setSystem("http://temp.org")
-                .setValue("TEMP-999")
-                .setType(new CodeableConcept())); // coding filtered out
+                .setValue("TEMP-999")); // type omitted: coding filtered out left it empty
 
         assertThat(tgt.equalsDeep(expected)).isTrue();
+    }
+
+    @Test
+    void omitsElementLeftEmptyByPartialCopy() throws ReflectiveOperationException {
+        // --- Given: maritalStatus has a coding, but no extension ---
+        Patient src = new Patient();
+        src.setMaritalStatus(new CodeableConcept().addCoding(new Coding()
+                .setSystem("http://terminology.hl7.org/CodeSystem/v3-MaritalStatus").setCode("M")));
+
+        Patient tgt = new Patient();
+
+        // --- Copy Tree: only the (non-matching) extension is requested, not coding/text ---
+        CopyTreeNode copyTree = new CopyTreeNode("Patient", "", List.of(
+                new CopyTreeNode("maritalStatus", "", List.of(
+                        new CopyTreeNode("extension", ".where(url='http://example.org/unused')", List.of())
+                ))
+        ));
+
+        // --- When ---
+        copyService.copy(src, tgt, copyTree);
+
+        // --- Then: none of the requested sub-elements matched, so maritalStatus must be entirely
+        // absent rather than an empty CodeableConcept ({}), which would violate FHIR's ele-1 invariant ---
+        assertThat(tgt.hasMaritalStatus()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `ElementCopier.copy()` created a target container as soon as the source FHIRPath resolved to something, then recursed into only the requested sub-children — if none of them matched, the container was still set on the target as a genuinely empty object (`{}`), violating the FHIR `ele-1` invariant ("all elements must have a @value or children").
- Filter out target elements that end up empty (`Base.isEmpty()`, which HAPI already implements per-type and correctly treats a data-absent-reason-masked element as non-empty) before assigning them to the field, so an absent field falls through to `Redaction`'s existing (already-correct) required-field handling instead of being emitted as `{}`.

## Test plan
- [x] `ElementCopierTest.nestedList` updated — its previous expectation (`new CodeableConcept()`) encoded the bug; now asserts the field is omitted entirely.
- [x] Added `ElementCopierTest.omitsElementLeftEmptyByPartialCopy` reproducing the empty-container case directly.
- [x] `mvn -Dtest=RedactionTest,ElementCopierTest test` — 47 tests, 0 failures.
- [x] `mvn -Dtest=BatchCopierRedacterIT test` — 7 tests, 0 failures.

Closes #1136