### PR TITLE
Fix Redaction Stripping Nested Content From Composite Extensions

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/torch/model/management/MultiElementContext.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/model/management/MultiElementContext.java
@@ -57,6 +57,17 @@ public record MultiElementContext(List<ElementContext> contexts) {
         return !isDataAbsentReason(extension) && !hasSlice(extension);
     }
 
+    /**
+     * Checks whether at least one context resolves an {@link ElementDefinition} for this element.
+     * <p>
+     * A composite extension's own internal slicing (e.g. an extension nested inside another extension)
+     * is defined in that extension's own StructureDefinition, not the containing profile's, so it
+     * commonly can't be resolved here at all.
+     */
+    public boolean isResolvable() {
+        return contexts.stream().anyMatch(ctx -> ctx.elementDefinition().isPresent());
+    }
+
     public boolean ignoreSlicingInRedaction() {
         return contexts.stream()
                 .map(ElementContext::elementId)

--- a/src/main/java/de/medizininformatikinitiative/torch/util/Redaction.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/util/Redaction.java
@@ -146,23 +146,42 @@ public class Redaction {
 
     /**
      * Removes extensions from the given FHIR element that are not allowed by slicing rules.
+     * <p>
+     * Skipped when {@code base} is itself an {@link Extension} whose own nested extension slot can't be
+     * resolved: a composite extension's internal slicing (e.g. an extension nested inside another
+     * extension) is defined in that extension's own StructureDefinition, not the containing profile's,
+     * so Torch commonly has no information to judge such children and must not delete them.
      *
      * @param base    the FHIR element from which unknown extensions should be removed
      * @param context the context containing allowed extensions for validation
      */
     private void removeUnknownExtensions(Base base, MultiElementContext context) {
+        if (base instanceof Extension && !context.isResolvable()) {
+            return;
+        }
         getExtensions(base).stream().filter(context::shouldRedactExtension).forEach(extension -> base.removeChild(EXTENSION, extension));
     }
 
     /**
      * Redacts known extensions of the given FHIR element using the provided structure definitions.
+     * <p>
+     * An extension left with neither a value nor nested extensions afterward is removed: {@link Base#isEmpty()}
+     * treats a {@code url}-only extension as non-empty since {@code url} technically counts as a child per
+     * FHIR's own model, but HAPI's serializers write nothing for such an extension anyway, so leaving it in
+     * place produces a container that appears empty on the wire (violating {@code ele-1}) despite passing
+     * {@code isEmpty()}.
      *
      * @param base       the FHIR element whose remaining extensions should be processed
      * @param context    the context for redacting extensions
      * @param references Map of allowed references
      */
     private void redactKnownExtensions(Base base, MultiElementContext context, Map<String, Set<ExtractionId>> references) {
-        getExtensions(base).forEach(extension -> redactChildren(extension, context, references));
+        getExtensions(base).forEach(extension -> {
+            redactChildren(extension, context, references);
+            if (!extension.hasValue() && !extension.hasExtension()) {
+                base.removeChild(EXTENSION, extension);
+            }
+        });
     }
 
     private List<Extension> getExtensions(Base base) {
@@ -202,7 +221,15 @@ public class Redaction {
      * @return updated ElementContexts if valid, otherwise Optional empty if element was removed due to slicing
      */
     private Optional<MultiElementContext> handleSlicing(Base dataElement, MultiElementContext context) {
-        if (dataElement instanceof Extension || !context.hasSlicing() || context.ignoreSlicingInRedaction()) {
+        if (dataElement instanceof Extension extension) {
+            // Extensions are never wiped here for failing to match a slice — that's already handled by
+            // removeUnknownExtensions at the parent level. But the context must still be narrowed to the
+            // matched slice (if any), so that checks against the extension's own nested content (e.g. a
+            // composite extension's sub-extensions) resolve against the right element ID instead of an
+            // unqualified path that can never resolve.
+            return Optional.of(context.mergeWithSlices(context.matchingSlices(extension)));
+        }
+        if (!context.hasSlicing() || context.ignoreSlicingInRedaction()) {
             return Optional.of(context);
         }
         return context.resolveSlices(dataElement, slices -> {

--- a/src/main/java/de/medizininformatikinitiative/torch/util/Slicing.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/util/Slicing.java
@@ -56,15 +56,20 @@ public class Slicing {
             for (ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent discriminator : slicingDiscriminator) {
                 if ("url".equals(discriminator.getPath()) && "VALUE".equals(discriminator.getType().toString())) {
                     if ("Extension".equals(element.getType().getFirst().getWorkingCode())) {
-                        UriType baseTypeUrl = (UriType) base.getNamedProperty("url").getValues().getFirst();
                         List<CanonicalType> profiles = element.getType().stream().flatMap(type -> type.getProfile().stream()).toList();
-                        // Check if any profile matches the base type URL
-                        boolean anyMatchBaseUrl = profiles.stream().anyMatch(profile -> profile.getValue().equals(baseTypeUrl.getValue()));
-                        if (anyMatchBaseUrl) {
-                            continue;
-                        } else {
-                            foundSlice = false;
-                            break;
+                        // A slice referencing its own standalone StructureDefinition (e.g. a composite extension)
+                        // is matched by profile URL. A slice with no declared profile (e.g. a nested sub-extension
+                        // sliced by a fixed value on its own .url child) has nothing to compare here, so it falls
+                        // through to the normal discriminator resolution below instead of being declared "no match".
+                        if (!profiles.isEmpty()) {
+                            UriType baseTypeUrl = (UriType) base.getNamedProperty("url").getValues().getFirst();
+                            boolean anyMatchBaseUrl = profiles.stream().anyMatch(profile -> profile.getValue().equals(baseTypeUrl.getValue()));
+                            if (anyMatchBaseUrl) {
+                                continue;
+                            } else {
+                                foundSlice = false;
+                                break;
+                            }
                         }
                     }
                 }

--- a/src/test/java/de/medizininformatikinitiative/torch/service/BatchCopierRedacterIT.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/service/BatchCopierRedacterIT.java
@@ -498,6 +498,217 @@ class BatchCopierRedacterIT {
             assertThat(out.getAddressFirstRep().getPostalCode()).isEqualTo("10178");
         }
 
+        @Test
+        void dischargeDispositionOmittedWhenOnlyUnmatchedSubFieldRequested() {
+            // GIVEN: real-world instance carries dischargeDisposition only via the German
+            // "Entlassungsgrund" extension (nested composite extension), not via .coding
+            String encounterJson = """
+                    {
+                      "resourceType": "Encounter",
+                      "id": "enc-discharge",
+                      "meta": {
+                        "profile": ["https://www.medizininformatik-initiative.de/fhir/core/modul-fall/StructureDefinition/KontaktGesundheitseinrichtung"]
+                      },
+                      "status": "finished",
+                      "hospitalization": {
+                        "dischargeDisposition": {
+                          "extension": [ {
+                            "url": "http://fhir.de/StructureDefinition/Entlassungsgrund",
+                            "extension": [
+                              { "url": "ErsteUndZweiteStelle", "valueCoding": { "code": "01", "system": "http://fhir.de/CodeSystem/dkgev/EntlassungsgrundErsteUndZweiteStelle" } },
+                              { "url": "DritteStelle", "valueCoding": { "code": "1", "system": "http://fhir.de/CodeSystem/dkgev/EntlassungsgrundDritteStelle" } }
+                            ]
+                          } ]
+                        }
+                      }
+                    }""";
+
+            Encounter encounter = parser.parseResource(Encounter.class, encounterJson);
+
+            // CRTDL only asks for the standard "coding" representation of dischargeDisposition,
+            // which this instance never populates.
+            AnnotatedAttributeGroup group = new AnnotatedAttributeGroup(
+                    "Encounter1", "Encounter",
+                    "https://www.medizininformatik-initiative.de/fhir/core/modul-fall/StructureDefinition/KontaktGesundheitseinrichtung",
+                    List.of(
+                            new AnnotatedAttribute("Encounter.id", "Encounter.id", false),
+                            new AnnotatedAttribute("Encounter.meta.profile", "Encounter.meta.profile", false),
+                            new AnnotatedAttribute("Encounter.hospitalization.dischargeDisposition.coding", "Encounter.hospitalization.dischargeDisposition.coding", false)),
+                    List.of());
+
+            PatientResourceBundle bundle = new PatientResourceBundle("PatientBundle");
+            bundle.put(encounter, "Encounter1", true);
+
+            ExtractionResourceBundle result = batchCopierRedacter.transformBundle(
+                    ExtractionResourceBundle.of(bundle), Map.of("Encounter1", group));
+
+            assertThat(result.cache()).hasSize(1);
+            Encounter out = (Encounter) result.markMissing(ExtractionId.fromRelativeUrl("Encounter/enc-discharge")).orElseThrow();
+            String actualJson = parser.setPrettyPrint(true).encodeResourceToString(out);
+
+            // Regression for #1136: an unmatched sub-element must leave the whole container absent,
+            // never emitted as an empty object ("dischargeDisposition":{}), which violates FHIR's ele-1 invariant.
+            assertThat(actualJson).doesNotContain("dischargeDisposition");
+            assertThat(out.hasHospitalization()).isFalse();
+        }
+
+        @Test
+        void nestedExtensionContentSurvivesRedactionWhenWholeDischargeDispositionRequested() {
+            // GIVEN: the same composite "Entlassungsgrund" extension (an extension nested inside
+            // another extension), but this time the whole dischargeDisposition is requested wholesale
+            String encounterJson = """
+                    {
+                      "resourceType": "Encounter",
+                      "id": "enc-discharge-2",
+                      "meta": {
+                        "profile": ["https://www.medizininformatik-initiative.de/fhir/core/modul-fall/StructureDefinition/KontaktGesundheitseinrichtung"]
+                      },
+                      "status": "finished",
+                      "hospitalization": {
+                        "dischargeDisposition": {
+                          "extension": [ {
+                            "url": "http://fhir.de/StructureDefinition/Entlassungsgrund",
+                            "extension": [
+                              { "url": "ErsteUndZweiteStelle", "valueCoding": { "code": "01", "system": "http://fhir.de/CodeSystem/dkgev/EntlassungsgrundErsteUndZweiteStelle" } },
+                              { "url": "DritteStelle", "valueCoding": { "code": "1", "system": "http://fhir.de/CodeSystem/dkgev/EntlassungsgrundDritteStelle" } }
+                            ]
+                          } ]
+                        }
+                      }
+                    }""";
+
+            Encounter encounter = parser.parseResource(Encounter.class, encounterJson);
+
+            AnnotatedAttributeGroup group = new AnnotatedAttributeGroup(
+                    "Encounter1", "Encounter",
+                    "https://www.medizininformatik-initiative.de/fhir/core/modul-fall/StructureDefinition/KontaktGesundheitseinrichtung",
+                    List.of(
+                            new AnnotatedAttribute("Encounter.id", "Encounter.id", false),
+                            new AnnotatedAttribute("Encounter.meta.profile", "Encounter.meta.profile", false),
+                            new AnnotatedAttribute("Encounter.hospitalization.dischargeDisposition", "Encounter.hospitalization.dischargeDisposition", false)),
+                    List.of());
+
+            PatientResourceBundle bundle = new PatientResourceBundle("PatientBundle");
+            bundle.put(encounter, "Encounter1", true);
+
+            ExtractionResourceBundle result = batchCopierRedacter.transformBundle(
+                    ExtractionResourceBundle.of(bundle), Map.of("Encounter1", group));
+
+            assertThat(result.cache()).hasSize(1);
+            Encounter out = (Encounter) result.markMissing(ExtractionId.fromRelativeUrl("Encounter/enc-discharge-2")).orElseThrow();
+            String actualJson = parser.setPrettyPrint(true).encodeResourceToString(out);
+
+            // Regression for #1138: redaction must not strip a composite extension's own nested
+            // extensions just because their definition lives in that extension's own StructureDefinition
+            // (unresolvable here), rather than the containing profile's.
+            assertThat(actualJson).doesNotContain("\"dischargeDisposition\": { }");
+            assertThat(actualJson).contains("\"code\": \"01\"");
+            assertThat(actualJson).contains("\"code\": \"1\"");
+        }
+
+        @Test
+        void dischargeDispositionOmittedWhenCompositeExtensionHasNoMeaningfulContent() {
+            // GIVEN: a malformed source where the composite "Entlassungsgrund" extension carries only its
+            // own url and none of its nested sub-extensions
+            String encounterJson = """
+                    {
+                      "resourceType": "Encounter",
+                      "id": "enc-discharge-3",
+                      "meta": {
+                        "profile": ["https://www.medizininformatik-initiative.de/fhir/core/modul-fall/StructureDefinition/KontaktGesundheitseinrichtung"]
+                      },
+                      "status": "finished",
+                      "hospitalization": {
+                        "dischargeDisposition": {
+                          "extension": [ { "url": "http://fhir.de/StructureDefinition/Entlassungsgrund" } ]
+                        }
+                      }
+                    }""";
+
+            Encounter encounter = parser.parseResource(Encounter.class, encounterJson);
+
+            AnnotatedAttributeGroup group = new AnnotatedAttributeGroup(
+                    "Encounter1", "Encounter",
+                    "https://www.medizininformatik-initiative.de/fhir/core/modul-fall/StructureDefinition/KontaktGesundheitseinrichtung",
+                    List.of(
+                            new AnnotatedAttribute("Encounter.id", "Encounter.id", false),
+                            new AnnotatedAttribute("Encounter.meta.profile", "Encounter.meta.profile", false),
+                            new AnnotatedAttribute("Encounter.hospitalization.dischargeDisposition", "Encounter.hospitalization.dischargeDisposition", false)),
+                    List.of());
+
+            PatientResourceBundle bundle = new PatientResourceBundle("PatientBundle");
+            bundle.put(encounter, "Encounter1", true);
+
+            ExtractionResourceBundle result = batchCopierRedacter.transformBundle(
+                    ExtractionResourceBundle.of(bundle), Map.of("Encounter1", group));
+
+            assertThat(result.cache()).hasSize(1);
+            Encounter out = (Encounter) result.markMissing(ExtractionId.fromRelativeUrl("Encounter/enc-discharge-3")).orElseThrow();
+            String actualJson = parser.setPrettyPrint(true).encodeResourceToString(out);
+
+            // Regression for #1138: a url-only extension (no value, no children) is invisible to HAPI's
+            // serializer despite Base#isEmpty() reporting it as non-empty. Left in place, the containing
+            // dischargeDisposition would still serialize as an empty object ("dischargeDisposition":{}),
+            // violating ele-1. It must be removed so the whole container is correctly omitted instead.
+            //
+            // Asserted on the serialized JSON rather than object state: hospitalization.dischargeDisposition
+            // stays a non-null (but now internally empty) reference at the Java level — it's HAPI's own
+            // serializer that omits an isEmpty() composite from the wire, not Torch clearing the field.
+            assertThat(actualJson).doesNotContain("dischargeDisposition");
+        }
+
+        @Test
+        void trulyUnknownNestedExtensionStillStrippedWhenCompositeExtensionIsResolvable() {
+            // GIVEN: unlike "Entlassungsgrund", the composite "Aufnahmegrund" extension has its own nested
+            // sub-extensions (ErsteUndZweiteStelle/DritteStelle/VierteStelle) fully inlined in this same
+            // profile's snapshot, so they ARE resolvable here. One recognized sub-extension plus one
+            // genuinely unrecognized one is attached.
+            String encounterJson = """
+                    {
+                      "resourceType": "Encounter",
+                      "id": "enc-admission",
+                      "meta": {
+                        "profile": ["https://www.medizininformatik-initiative.de/fhir/core/modul-fall/StructureDefinition/KontaktGesundheitseinrichtung"]
+                      },
+                      "status": "finished",
+                      "extension": [ {
+                        "url": "http://fhir.de/StructureDefinition/Aufnahmegrund",
+                        "extension": [
+                          { "url": "ErsteUndZweiteStelle", "valueCoding": { "code": "01", "system": "http://fhir.de/CodeSystem/dkgev/AufnahmeanlassErsteUndZweiteStelle" } },
+                          { "url": "notARealSubExtension", "valueString": "garbage" }
+                        ]
+                      } ]
+                    }""";
+
+            Encounter encounter = parser.parseResource(Encounter.class, encounterJson);
+
+            AnnotatedAttributeGroup group = new AnnotatedAttributeGroup(
+                    "Encounter1", "Encounter",
+                    "https://www.medizininformatik-initiative.de/fhir/core/modul-fall/StructureDefinition/KontaktGesundheitseinrichtung",
+                    List.of(
+                            new AnnotatedAttribute("Encounter.id", "Encounter.id", false),
+                            new AnnotatedAttribute("Encounter.meta.profile", "Encounter.meta.profile", false),
+                            new AnnotatedAttribute("Encounter.extension:Aufnahmegrund", "Encounter.extension.where(url='http://fhir.de/StructureDefinition/Aufnahmegrund')", false)),
+                    List.of());
+
+            PatientResourceBundle bundle = new PatientResourceBundle("PatientBundle");
+            bundle.put(encounter, "Encounter1", true);
+
+            ExtractionResourceBundle result = batchCopierRedacter.transformBundle(
+                    ExtractionResourceBundle.of(bundle), Map.of("Encounter1", group));
+
+            assertThat(result.cache()).hasSize(1);
+            Encounter out = (Encounter) result.markMissing(ExtractionId.fromRelativeUrl("Encounter/enc-admission")).orElseThrow();
+            String actualJson = parser.setPrettyPrint(true).encodeResourceToString(out);
+
+            // The recognized sub-extension survives, but the genuinely unknown one must still be stripped:
+            // when a composite extension's own nesting IS resolvable, ordinary unknown-extension removal
+            // must keep working, not be bypassed by the #1138 guard meant for the unresolvable case.
+            assertThat(actualJson).contains("\"code\": \"01\"");
+            assertThat(actualJson).doesNotContain("notARealSubExtension");
+            assertThat(actualJson).doesNotContain("garbage");
+        }
+
         @Nested
         class transformBatch {
             @Test


### PR DESCRIPTION
## Summary

- `Redaction` resolves whether an extension is "known" (part of the declared profile) by looking up its dotted element-ID path in the *containing* profile's snapshot. A composite extension's own nested extensions (e.g. the German `Entlassungsgrund` discharge-reason extension, containing `ErsteUndZweiteStelle`/`DritteStelle`) are defined in that extension's *own* StructureDefinition, not the containing profile's — so the lookup for the nested path fails, and "not found" was being treated the same as "found, but not a declared slice", i.e. stripped as unknown. This deleted legitimate, already-copied nested content, leaving the outer extension as bare `{"url": "..."}`.
- HAPI's own JSON serializer silently omits an extension with a `url` but no value and no children, so that bare extension vanished from the wire entirely — even though `hasExtension()`/`isEmpty()` on the in-memory object still (misleadingly) report content. The end result was the containing field (`dischargeDisposition`) serializing as an empty object, still violating `ele-1` despite #1136/#1137.
- Two fixes in `Redaction`:
  1. `removeUnknownExtensions`: don't strip a composite extension's own nested extensions when their definition can't be resolved at all — only when the containing element is itself an `Extension`, so ordinary vendor-extension stripping elsewhere (primitives, top-level fields) is untouched.
  2. `redactKnownExtensions`: after redacting an extension's children, remove the extension itself if it ends up with neither a value nor nested extensions, closing the gap between `Base#isEmpty()` and what HAPI actually serializes.
- Coverage follow-up: the first fix relies on `handleSlicing` bypassing slice-context narrowing entirely for `Extension`-typed elements, which meant its "resolvable" branch was never actually reachable — `isResolvable()` always saw an unqualified, unresolvable path regardless of whether the extension's own nesting was genuinely known. Fixed `handleSlicing` to narrow the context to the matched slice for extensions too (without the "wipe if no match" behavior, which is already handled elsewhere for extensions).
- That narrowing exposed a separate, pre-existing bug in `Slicing.resolveSlicing`: its `url`-discriminator matching special-cases extension slices with a declared `type.profile` (e.g. `Entlassungsgrund`), but nested sub-extensions sliced the more common way — a fixed value on their own `.url` child, no `type.profile` — were unconditionally declared "no match" instead of falling through to normal discriminator resolution. Fixed to only take the profile-matching shortcut when a profile is actually declared.

## Test plan

- [x] Reproduced both original failure modes against unfixed code (composite extension content wiped; url-only extension surviving as an invisible-but-`isEmpty()==false` stub) before applying each fix, confirmed they pass after.
- [x] Added a regression test proving a genuinely unknown nested extension (inside a *resolvable* composite extension, `Aufnahmegrund`) is still correctly stripped — this is what caught both the context-narrowing gap and the `Slicing` discriminator bug.
- [x] `mvn -Dtest=RedactionTest,BatchCopierRedacterIT,ElementCopierTest,SlicingTest test` — 66 tests, 0 failures.
- [x] Full non-container unit suite (`mvn -Dtest='*Test' test`) — 1186 tests, 0 failures (17 pre-existing/flaky failures in `CrtdlConsentValidatorTest`/`JobSchedulerTest` reproduced identically on unmodified code, unrelated to this change).

Closes #1138