### PR TITLE
Release v1.0.0-beta.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+## [v1.0.0-beta.7.1] - 2026-08-03
+
+### Fixed
+
+- Fix Redaction Stripping Nested Content From Composite Extensions [#1139](https://github.com/medizininformatik-initiative/torch/pull/1139)
+
+
 ## [v1.0.0-beta.7] - 2026-07-27
 
 ### Added

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -178,17 +178,17 @@ For container images, we use cosign to sign images. This allows users to confirm
 pipeline and has not been modified after publication.
 
 ```
-cosign verify "ghcr.io/medizininformatik-initiative/torch:v1.0.0-beta.7" \
+cosign verify "ghcr.io/medizininformatik-initiative/torch:v1.0.0-beta.7.1" \
 --certificate-identity-regexp "https://github.com/medizininformatik-initiative/torch.*" \
 --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
---certificate-github-workflow-ref="refs/tags/v1.0.0-beta.7" \
+--certificate-github-workflow-ref="refs/tags/v1.0.0-beta.7.1" \
 -o text
 ```
 
 The expected output is:
 
 ```
-Verification for ghcr.io/medizininformatik-initiative/torch:v1.0.0-beta.7 --
+Verification for ghcr.io/medizininformatik-initiative/torch:v1.0.0-beta.7.1 --
 The following checks were performed on each of these signatures:
 - The cosign claims were validated
 - Existence of the claims in the transparency log was verified offline
@@ -196,5 +196,5 @@ The following checks were performed on each of these signatures:
 ```
 
 This output ensures that the image was build on the GitHub workflow on the repository
-`medizininformatik-initiative/torch` and tag `v1.0.0-beta.7`.
+`medizininformatik-initiative/torch` and tag `v1.0.0-beta.7.1`.
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>de.medizininformatikinitiative</groupId>
     <artifactId>torch</artifactId>
-    <version>v1.0.0-beta.7</version>
+    <version>v1.0.0-beta.7.1</version>
 
     <properties>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
## Summary
- Patch release bundling the redaction fix for #1138 (PR #1139)
- Bumps version to `v1.0.0-beta.7.1` in pom.xml and updates the cosign verification example in docs/deployment.md
- Adds CHANGELOG entry

## Test plan
- [ ] Review CHANGELOG entry
- [ ] Merge and tag `v1.0.0-beta.7.1` on main