### PR TITLE
Add Heap Warn Log

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -235,6 +235,33 @@ Must include an explicit scheme (`http://` or `https://`). TORCH will fail at st
 
 ---
 
+#### `TORCH_JVM_METRICS_LOGGER_INTERVAL` <Badge type="warning" text="Since 1.0.0"/>
+
+The interval at which JVM heap, non-heap, and GC metrics are logged at `DEBUG` level when heap usage is
+below `TORCH_JVM_METRICS_LOGGER_WARN_THRESHOLD`. Must be an ISO-8601 duration string.
+Note that the `DEBUG` line is only visible when `LOG_LEVEL_DE_MEDIZININFORMATIKINITIATIVE_TORCH` is set to `debug` or lower.
+
+**Default:** `PT5M`
+
+---
+
+#### `TORCH_JVM_METRICS_LOGGER_WARN_FACTOR` <Badge type="warning" text="Since 1.0.0"/>
+
+How many times more frequently metrics are logged at `WARN` level compared to `TORCH_JVM_METRICS_LOGGER_INTERVAL`
+when heap usage is at or above `TORCH_JVM_METRICS_LOGGER_WARN_THRESHOLD`. Must be a positive integer.
+
+**Default:** `5`
+
+---
+
+#### `TORCH_JVM_METRICS_LOGGER_WARN_THRESHOLD` <Badge type="warning" text="Since 1.0.0"/>
+
+The heap usage percentage (1-99) at or above which metrics are logged at `WARN` level and at the shorter warn interval.
+
+**Default:** `80`
+
+---
+
 #### `LOG_LEVEL_DE_MEDIZININFORMATIKINITIATIVE_TORCH` <Badge type="warning" text="Since 1.0.0-alpha"/>
 
 Logging level for core TORCH functionality (`error`/ `warn`/ `info`/ `debug`/ `trace`).

--- a/src/main/java/de/medizininformatikinitiative/torch/config/JvmMetricsLoggerProperties.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/config/JvmMetricsLoggerProperties.java
@@ -1,0 +1,20 @@
+package de.medizininformatikinitiative.torch.config;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import java.time.Duration;
+
+@ConfigurationProperties(prefix = "torch.jvm-metrics-logger")
+@Validated
+public record JvmMetricsLoggerProperties(
+        @NotNull(message = "Interval is required") Duration interval,
+        @Min(value = 1, message = "Warn factor must be at least 1")
+        @Max(value = 999, message = "Warn factor must be at most 999") int warnFactor,
+        @Min(value = 1, message = "Warn threshold must be at least 1")
+        @Max(value = 99, message = "Warn threshold must be at most 99") int warnThreshold
+) {
+}

--- a/src/main/java/de/medizininformatikinitiative/torch/config/TorchPropertiesConfig.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/config/TorchPropertiesConfig.java
@@ -6,7 +6,8 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @EnableConfigurationProperties({
         TorchProperties.class,
-        FhirProperties.class
+        FhirProperties.class,
+        JvmMetricsLoggerProperties.class
 })
 public class TorchPropertiesConfig {
 }

--- a/src/main/java/de/medizininformatikinitiative/torch/monitoring/JvmMetricsLogger.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/monitoring/JvmMetricsLogger.java
@@ -1,0 +1,111 @@
+package de.medizininformatikinitiative.torch.monitoring;
+
+import de.medizininformatikinitiative.torch.config.JvmMetricsLoggerProperties;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryUsage;
+import java.time.Duration;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+/**
+ * Periodically logs JVM heap, non-heap, and GC usage so that heap pressure is visible in the
+ * application log even without a Prometheus setup.
+ *
+ * <p>Runs on its own single-thread scheduler at a fixed tick of {@code interval / warnFactor}, so
+ * that the more frequent, high-priority check for elevated heap usage is never delayed by unrelated
+ * blocking work on Spring's shared task scheduler. On each tick, if heap usage is at or above
+ * {@code warnThreshold}, a line is logged at {@code WARN}. Otherwise, a line is logged at
+ * {@code DEBUG} every {@code warnFactor}-th tick, i.e. roughly every {@code interval}. The two cases
+ * are mutually exclusive so elevated usage does not also produce a redundant {@code DEBUG} line.</p>
+ */
+@Service
+public class JvmMetricsLogger {
+
+    private static final Logger logger = LoggerFactory.getLogger(JvmMetricsLogger.class);
+
+    private static final long BYTES_PER_GB = 1024L * 1024 * 1024;
+    private static final long BYTES_PER_MB = 1024L * 1024;
+
+    private final JvmMetricsLoggerProperties properties;
+    private final MemoryMXBean memoryMXBean;
+    private final ScheduledExecutorService scheduler;
+    private final AtomicLong tickCount = new AtomicLong();
+
+    @Autowired
+    public JvmMetricsLogger(JvmMetricsLoggerProperties properties) {
+        this(properties, ManagementFactory.getMemoryMXBean(),
+                Executors.newSingleThreadScheduledExecutor(r -> new Thread(r, "jvm-metrics-logger")));
+    }
+
+    JvmMetricsLogger(JvmMetricsLoggerProperties properties, MemoryMXBean memoryMXBean, ScheduledExecutorService scheduler) {
+        this.properties = properties;
+        this.memoryMXBean = memoryMXBean;
+        this.scheduler = scheduler;
+    }
+
+    @PostConstruct
+    void start() {
+        Duration tickInterval = properties.interval().dividedBy(properties.warnFactor());
+        logger.info("Start JVM metrics logger with an interval of {}, a warn factor of {} and a warn threshold of {}%",
+                properties.interval(), properties.warnFactor(), properties.warnThreshold());
+        scheduler.scheduleAtFixedRate(this::logMetrics, tickInterval.toMillis(), tickInterval.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    @PreDestroy
+    void stop() {
+        scheduler.shutdownNow();
+    }
+
+    void logMetrics() {
+        MemoryUsage heap = memoryMXBean.getHeapMemoryUsage();
+        MemoryUsage nonHeap = memoryMXBean.getNonHeapMemoryUsage();
+        List<GarbageCollectorMXBean> gcBeans = ManagementFactory.getGarbageCollectorMXBeans();
+        int pct = heapUsagePercent(heap);
+        long tick = tickCount.incrementAndGet();
+
+        if (pct >= properties.warnThreshold()) {
+            logger.warn("High heap usage - {}", usageLine(heap, nonHeap, gcBeans, pct));
+        } else if (tick % properties.warnFactor() == 0) {
+            logger.debug(usageLine(heap, nonHeap, gcBeans, pct));
+        }
+    }
+
+    static int heapUsagePercent(MemoryUsage usage) {
+        long max = usage.getMax();
+        return max > 0 ? (int) (100L * usage.getUsed() / max) : 0;
+    }
+
+    static String usageLine(MemoryUsage heap, MemoryUsage nonHeap, List<GarbageCollectorMXBean> gcBeans, int pct) {
+        String gcPart = gcBeans.stream().map(JvmMetricsLogger::formatGc).collect(Collectors.joining(", "));
+        return String.format(Locale.ROOT, "Heap: %s used / %s committed / %s max (%d%%), Non-Heap: %s used / %s committed%s",
+                formatBytes(heap.getUsed()), formatBytes(heap.getCommitted()), formatBytes(heap.getMax()), pct,
+                formatBytes(nonHeap.getUsed()), formatBytes(nonHeap.getCommitted()),
+                gcPart.isEmpty() ? "" : ", GC: " + gcPart);
+    }
+
+    private static String formatGc(GarbageCollectorMXBean gc) {
+        long count = gc.getCollectionCount();
+        double seconds = gc.getCollectionTime() / 1000.0;
+        return String.format(Locale.ROOT, "%s %d %s %.1fs", gc.getName(), count, count == 1 ? "collection" : "collections", seconds);
+    }
+
+    private static String formatBytes(long bytes) {
+        return bytes >= BYTES_PER_GB
+                ? String.format(Locale.ROOT, "%.1f GB", bytes / (double) BYTES_PER_GB)
+                : String.format(Locale.ROOT, "%.0f MB", bytes / (double) BYTES_PER_MB);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,6 +47,10 @@ torch:
     file:
       server:
         url: http://localhost:8080/output
+  jvm-metrics-logger:
+    interval: PT5M
+    warn-factor: 5
+    warn-threshold: 80
 logging:
   level:
     de.medizininformatikinitiative.torch: ${LOG_LEVEL:info}

--- a/src/test/java/de/medizininformatikinitiative/torch/monitoring/JvmMetricsLoggerTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/monitoring/JvmMetricsLoggerTest.java
@@ -1,0 +1,211 @@
+package de.medizininformatikinitiative.torch.monitoring;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import de.medizininformatikinitiative.torch.config.JvmMetricsLoggerProperties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryUsage;
+import java.time.Duration;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JvmMetricsLoggerTest {
+
+    @Mock
+    MemoryMXBean memoryMXBean;
+    @Mock
+    ScheduledExecutorService scheduler;
+
+    private ch.qos.logback.classic.Logger logbackLogger;
+    private ListAppender<ILoggingEvent> appender;
+
+    @BeforeEach
+    void setUp() {
+        logbackLogger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(JvmMetricsLogger.class);
+        logbackLogger.setLevel(Level.TRACE);
+        appender = new ListAppender<>();
+        appender.start();
+        logbackLogger.addAppender(appender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        logbackLogger.detachAppender(appender);
+    }
+
+    private static MemoryUsage memoryUsage(long used, long committed, long max) {
+        return new MemoryUsage(0, used, committed, max);
+    }
+
+    private static GarbageCollectorMXBean gcBean(String name, long count, long timeMs) {
+        return new GarbageCollectorMXBean() {
+            @Override
+            public long getCollectionCount() {
+                return count;
+            }
+
+            @Override
+            public long getCollectionTime() {
+                return timeMs;
+            }
+
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public boolean isValid() {
+                return true;
+            }
+
+            @Override
+            public String[] getMemoryPoolNames() {
+                return new String[0];
+            }
+
+            @Override
+            public javax.management.ObjectName getObjectName() {
+                return null;
+            }
+        };
+    }
+
+    @Test
+    void heapUsagePercentComputesRoundedDownPercentage() {
+        assertThat(JvmMetricsLogger.heapUsagePercent(memoryUsage(500, 1000, 1000))).isEqualTo(50);
+    }
+
+    @Test
+    void heapUsagePercentReturnsZeroWhenMaxUndefined() {
+        assertThat(JvmMetricsLogger.heapUsagePercent(memoryUsage(500, 1000, -1))).isZero();
+    }
+
+    @Test
+    void usageLineFormatsMegabytesAndSingleCollection() {
+        MemoryUsage heap = memoryUsage(512 * 1024 * 1024L, 1024 * 1024 * 1024L, 2048 * 1024 * 1024L);
+        MemoryUsage nonHeap = memoryUsage(100 * 1024 * 1024L, 200 * 1024 * 1024L, -1);
+        GarbageCollectorMXBean gc = gcBean("G1 Young Generation", 1, 500);
+
+        String line = JvmMetricsLogger.usageLine(heap, nonHeap, List.of(gc), 25);
+
+        assertThat(line).isEqualTo("Heap: 512 MB used / 1.0 GB committed / 2.0 GB max (25%), " +
+                "Non-Heap: 100 MB used / 200 MB committed, GC: G1 Young Generation 1 collection 0.5s");
+    }
+
+    @Test
+    void usageLineFormatsGigabytesAndMultipleCollectionsAndIsLocaleIndependent() {
+        Locale original = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.GERMANY);
+            MemoryUsage heap = memoryUsage(1024 * 1024 * 1024L, 2048 * 1024 * 1024L, 2048 * 1024 * 1024L);
+            MemoryUsage nonHeap = memoryUsage(0, 0, -1);
+            GarbageCollectorMXBean gc = gcBean("G1 Old Generation", 5, 2000);
+
+            String line = JvmMetricsLogger.usageLine(heap, nonHeap, List.of(gc), 50);
+
+            assertThat(line).isEqualTo("Heap: 1.0 GB used / 2.0 GB committed / 2.0 GB max (50%), " +
+                    "Non-Heap: 0 MB used / 0 MB committed, GC: G1 Old Generation 5 collections 2.0s");
+        } finally {
+            Locale.setDefault(original);
+        }
+    }
+
+    @Test
+    void usageLineOmitsGcPartWhenNoBeans() {
+        MemoryUsage heap = memoryUsage(0, 0, 1000);
+        MemoryUsage nonHeap = memoryUsage(0, 0, -1);
+
+        String line = JvmMetricsLogger.usageLine(heap, nonHeap, List.of(), 0);
+
+        assertThat(line).isEqualTo("Heap: 0 MB used / 0 MB committed / 0 MB max (0%), Non-Heap: 0 MB used / 0 MB committed");
+    }
+
+    @Test
+    void logsWarnWhenHeapUsageAtOrAboveThreshold() {
+        when(memoryMXBean.getHeapMemoryUsage()).thenReturn(memoryUsage(900, 1000, 1000));
+        when(memoryMXBean.getNonHeapMemoryUsage()).thenReturn(memoryUsage(10, 20, -1));
+        var properties = new JvmMetricsLoggerProperties(Duration.ofMinutes(5), 5, 80);
+        var jvmMetricsLogger = new JvmMetricsLogger(properties, memoryMXBean, scheduler);
+
+        jvmMetricsLogger.logMetrics();
+
+        assertThat(appender.list).hasSize(1);
+        assertThat(appender.list.get(0).getLevel()).isEqualTo(Level.WARN);
+        assertThat(appender.list.get(0).getFormattedMessage()).startsWith("High heap usage - Heap:");
+    }
+
+    @Test
+    void logsDebugOnlyOnEveryWarnFactorTickWhenBelowThreshold() {
+        when(memoryMXBean.getHeapMemoryUsage()).thenReturn(memoryUsage(100, 1000, 1000));
+        when(memoryMXBean.getNonHeapMemoryUsage()).thenReturn(memoryUsage(10, 20, -1));
+        var properties = new JvmMetricsLoggerProperties(Duration.ofMinutes(5), 2, 80);
+        var jvmMetricsLogger = new JvmMetricsLogger(properties, memoryMXBean, scheduler);
+
+        jvmMetricsLogger.logMetrics();
+        assertThat(appender.list).isEmpty();
+
+        jvmMetricsLogger.logMetrics();
+        assertThat(appender.list).hasSize(1);
+        assertThat(appender.list.get(0).getLevel()).isEqualTo(Level.DEBUG);
+        assertThat(appender.list.get(0).getFormattedMessage()).startsWith("Heap:");
+    }
+
+    @Test
+    void tickCountAdvancesDuringWarnTicksSoDebugCadenceIsNotDelayed() {
+        var properties = new JvmMetricsLoggerProperties(Duration.ofMinutes(5), 3, 50);
+        var jvmMetricsLogger = new JvmMetricsLogger(properties, memoryMXBean, scheduler);
+
+        when(memoryMXBean.getNonHeapMemoryUsage()).thenReturn(memoryUsage(10, 20, -1));
+
+        when(memoryMXBean.getHeapMemoryUsage()).thenReturn(memoryUsage(100, 1000, 1000)); // 10%, tick 1
+        jvmMetricsLogger.logMetrics();
+        when(memoryMXBean.getHeapMemoryUsage()).thenReturn(memoryUsage(900, 1000, 1000)); // 90%, tick 2 -> WARN
+        jvmMetricsLogger.logMetrics();
+        when(memoryMXBean.getHeapMemoryUsage()).thenReturn(memoryUsage(100, 1000, 1000)); // 10%, tick 3 -> DEBUG
+        jvmMetricsLogger.logMetrics();
+
+        assertThat(appender.list).extracting(ILoggingEvent::getLevel).containsExactly(Level.WARN, Level.DEBUG);
+    }
+
+    @Test
+    void startSchedulesAtTickIntervalDerivedFromIntervalAndWarnFactor() {
+        var properties = new JvmMetricsLoggerProperties(Duration.ofMinutes(5), 5, 80);
+        var jvmMetricsLogger = new JvmMetricsLogger(properties, memoryMXBean, scheduler);
+
+        jvmMetricsLogger.start();
+
+        long expectedTickMillis = Duration.ofMinutes(1).toMillis();
+        verify(scheduler).scheduleAtFixedRate(any(), eq(expectedTickMillis), eq(expectedTickMillis), eq(TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    void stopShutsDownScheduler() {
+        var properties = new JvmMetricsLoggerProperties(Duration.ofMinutes(5), 5, 80);
+        var jvmMetricsLogger = new JvmMetricsLogger(properties, memoryMXBean, scheduler);
+
+        jvmMetricsLogger.stop();
+
+        verify(scheduler).shutdownNow();
+    }
+}


### PR DESCRIPTION
## Summary

Ports Blaze's periodic JVM heap/GC metrics logger ([samply/blaze#3523](https://github.com/samply/blaze/pull/3523)) onto Torch's Spring Boot stack.

- New `torch.jvm-metrics-logger.*` config (`interval`, `warn-factor`, `warn-threshold`; defaults `PT5M` / `5` / `80`), env-var overridable the same way as other `torch.*` settings (e.g. `TORCH_JVM_METRICS_LOGGER_WARN_THRESHOLD`).
- New `JvmMetricsLogger` service logs heap/non-heap/GC usage: `DEBUG` every `interval` while heap usage is below the threshold, `WARN` (at `interval / warn-factor`, i.e. more frequently) once usage reaches the threshold.
- Runs on its own dedicated single-thread scheduler rather than Spring's shared task scheduler, so it can't be delayed by `JobPersistenceService`'s blocking job-GC sweep on that same shared pool.
- Documented the three new env vars in `docs/configuration.md`, including that the `DEBUG` line needs `LOG_LEVEL=debug` to be visible (default root level is `info`; the dev `docker-compose.yml` stack already runs at `debug`).

Closes #1146

## Test plan

- [x] `mvn -Dtest=JvmMetricsLoggerTest test` — formatter/percentage unit tests (byte-unit boundaries, GC singular/plural, locale independence via `Locale.ROOT`), Logback `ListAppender` tests for WARN/DEBUG level selection and tick-counter cadence, scheduling lifecycle tests against a mocked `ScheduledExecutorService`.
- [x] `mvn -Dtest=TorchPropertiesTest,FhirPropertiesTest test` — no regressions in existing config property tests.
- [x] Verified Spring can actually instantiate the new `@Service` (ambiguous-constructor issue caught and fixed) via an ad-hoc `ApplicationContextRunner` check.
- [x] Verified relaxed env-var binding (`TORCH_JVM_METRICS_LOGGER_*`) and `@Min`/`@Max` validation via an ad-hoc `ApplicationContextRunner` check.