### PR TITLE
Verify Cohort Patient Count Against Exclusions And Final Patients

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/torch/diagnostics/JobDiagnosticSummary.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/diagnostics/JobDiagnosticSummary.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -47,6 +48,24 @@ public record JobDiagnosticSummary(@JsonProperty("Num-Cohort-Patients") int numC
         var finalPatients = sumFinalPatients(batchDiagnostics);
 
         return new JobDiagnosticSummary(cohortPatients, finalPatients, durations, patientExclusions, resourcesExclusions);
+    }
+
+    /**
+     * Verifies that every cohort patient is accounted for by either surviving extraction or being excluded.
+     *
+     * @return a description of the mismatch if {@code numCohortPatients} does not equal {@code numFinalPatients} plus
+     * the sum of all recorded patient exclusions, or empty if the counts agree
+     */
+    public Optional<String> verifyPatientCounts() {
+        int totalExcluded = patientSummaries.values().stream().mapToInt(Integer::intValue).sum();
+        int accountedFor = numFinalPatients + totalExcluded;
+
+        if (accountedFor != numCohortPatients) {
+            return Optional.of("Cohort patient count %d does not match final patient count %d plus recorded exclusions %d (%d)"
+                    .formatted(numCohortPatients, numFinalPatients, totalExcluded, accountedFor));
+        }
+
+        return Optional.empty();
     }
 
     /**

--- a/src/main/java/de/medizininformatikinitiative/torch/service/JobPersistenceService.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/service/JobPersistenceService.java
@@ -474,7 +474,12 @@ public class JobPersistenceService {
             Job updated = job.onCoreSuccess(result);
             if (updated.status() == JobStatus.COMPLETED) {
                 try {
-                    buildAndSaveDiagnosticsSummary(result.jobId());
+                    JobDiagnosticSummary summary = buildAndSaveDiagnosticsSummary(result.jobId());
+                    Optional<String> mismatch = summary.verifyPatientCounts();
+                    if (mismatch.isPresent()) {
+                        logger.warn("Job {} diagnostics inconsistency: {}", result.jobId(), mismatch.get());
+                        updated = updated.withIssuesAdded(List.of(Issue.simple(Severity.WARNING, mismatch.get())));
+                    }
                 } catch (IOException | CsvValidationException e) {
                     logger.warn("Failed to build job diagnostics summary for job {}: {}",
                             result.jobId(), e.getMessage(), e);
@@ -656,7 +661,7 @@ public class JobPersistenceService {
         return diagnosticsStore.readSummary(jobDir(jobId));
     }
 
-    public void buildAndSaveDiagnosticsSummary(UUID jobId) throws IOException, CsvValidationException {
+    public JobDiagnosticSummary buildAndSaveDiagnosticsSummary(UUID jobId) throws IOException, CsvValidationException {
         Map<String, BatchDiagnostics> batchDiagnostics = diagnosticsStore.loadAllDiagnostics(jobDir(jobId));
         JobDiagnosticSummary summary = JobDiagnosticSummary.initFromBatches(batchDiagnostics.values().stream().toList());
 
@@ -664,6 +669,8 @@ public class JobPersistenceService {
         diagnosticsStore.writeSummary(summary, jobDir(jobId));
 
         diagnosticsStore.deleteIntermediateDiagnostics(jobDir(jobId));
+
+        return summary;
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/java/de/medizininformatikinitiative/torch/diagnostics/JobDiagnosticsSummaryTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/diagnostics/JobDiagnosticsSummaryTest.java
@@ -220,5 +220,29 @@ public class JobDiagnosticsSummaryTest {
         assertThat(summary.numFinalPatients()).isEqualTo(NUM_1+NUM_2);
     }
 
+    @Nested
+    class TestVerifyPatientCounts {
+
+        @Test
+        void countsMatch_returnsEmpty() {
+            var batch = BatchDiagnostics.empty().setNumCohortPatients(5).setFinalPatientCount(3);
+            batch.batchExclusions().addPatientExclusion(PatientExclusionStage.CONSENT_FETCH, "pat-1");
+            batch.batchExclusions().addPatientExclusion(PatientExclusionStage.DIRECT_LOAD, "pat-2");
+
+            var summary = JobDiagnosticSummary.initFromBatches(List.of(batch));
+
+            assertThat(summary.verifyPatientCounts()).isEmpty();
+        }
+
+        @Test
+        void countsMismatch_returnsDescription() {
+            var batch = BatchDiagnostics.empty().setNumCohortPatients(5).setFinalPatientCount(3);
+            batch.batchExclusions().addPatientExclusion(PatientExclusionStage.CONSENT_FETCH, "pat-1");
+
+            var summary = JobDiagnosticSummary.initFromBatches(List.of(batch));
+
+            assertThat(summary.verifyPatientCounts()).isPresent();
+        }
+    }
 
 }

--- a/src/test/java/de/medizininformatikinitiative/torch/service/JobPersistenceServiceTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/service/JobPersistenceServiceTest.java
@@ -1174,6 +1174,48 @@ class JobPersistenceServiceTest {
             return new BatchResult(jobId, batchId, batchState, Optional.empty(),
                     Optional.of(diagnostics), List.of());
         }
+
+        @Test
+        void onCoreSuccess_patientCountsConsistent_noWarningIssueAdded() throws IOException {
+            var jobId = persistenceService.createJob(new AnnotatedCrtdl(
+                    JsonNodeFactory.instance.objectNode(),
+                    new AnnotatedDataExtraction(List.of()),
+                    Optional.empty()), List.of(), "");
+
+            var details = new BatchDetails(Map.of(), 2, 1);
+            var batchExclusions = BatchExclusions.empty();
+            batchExclusions.addPatientExclusion(PatientExclusionStage.DIRECT_LOAD, PATIENT_1);
+            var diagnostics = new BatchDiagnostics(batchExclusions, details);
+
+            persistenceService.selectNextInternal(jobId);
+            persistenceService.onCohortSuccess(jobId, List.of());
+            persistenceService.onBatchProcessingSuccess(createBatchResult(diagnostics, jobId, UUID.randomUUID()));
+            persistenceService.onCoreSuccess(new CoreResult(jobId, List.of(), WorkUnitStatus.FINISHED));
+
+            assertThat(persistenceService.getJob(jobId).orElseThrow().issues())
+                    .noneMatch(issue -> issue.severity() == Severity.WARNING && issue.msg().contains("Cohort patient count"));
+        }
+
+        @Test
+        void onCoreSuccess_patientCountsMismatch_addsWarningIssue() throws IOException {
+            var jobId = persistenceService.createJob(new AnnotatedCrtdl(
+                    JsonNodeFactory.instance.objectNode(),
+                    new AnnotatedDataExtraction(List.of()),
+                    Optional.empty()), List.of(), "");
+
+            var details = new BatchDetails(Map.of(), 2, 1);
+            var diagnostics = new BatchDiagnostics(BatchExclusions.empty(), details);
+
+            persistenceService.selectNextInternal(jobId);
+            persistenceService.onCohortSuccess(jobId, List.of());
+            persistenceService.onBatchProcessingSuccess(createBatchResult(diagnostics, jobId, UUID.randomUUID()));
+            persistenceService.onCoreSuccess(new CoreResult(jobId, List.of(), WorkUnitStatus.FINISHED));
+
+            var job = persistenceService.getJob(jobId).orElseThrow();
+            assertThat(job.status()).isEqualTo(JobStatus.COMPLETED);
+            assertThat(job.issues())
+                    .anyMatch(issue -> issue.severity() == Severity.WARNING && issue.msg().contains("Cohort patient count"));
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Summary
- Add `JobDiagnosticSummary.verifyPatientCounts()`, checking that `numCohortPatients` equals `numFinalPatients` plus the sum of all recorded patient exclusions.
- `JobPersistenceService.onCoreSuccess` now runs this check after building the job's diagnostics summary and attaches a `Severity.WARNING` `Issue` to the job on mismatch (visible via the `torch-job-issues` extension), in addition to logging it.
- `buildAndSaveDiagnosticsSummary` now returns the built `JobDiagnosticSummary` instead of `void` so the caller can run the check.

## Test plan
- [x] `JobDiagnosticsSummaryTest` — consistent counts return empty, mismatched counts return a description
- [x] `JobPersistenceServiceTest` — `onCoreSuccess` adds no warning issue when counts are consistent, adds one when they mismatch
- [x] `mvn -o test-compile` clean across the whole project

Closes #997