### PR TITLE
Expose Torch Prometheus Metrics Endpoint

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -294,14 +294,26 @@ Maximum allowed in-memory size for Spring codecs when processing data.
 
 ## Monitoring <Badge type="warning" text="Since 1.0.0-alpha.13"/>
 
-Torch allows monitoring using the Spring boot default actuator endpoints.
+Torch exposes a Prometheus-compatible metrics endpoint at `/actuator/prometheus`, on the same port as
+the application (`SERVER_PORT`, default `8080`; `8086` in the bundled `docker-compose.yml` stack). It is
+backed by the Spring Boot actuator; see the
+[Spring documentation](https://docs.spring.io/spring-boot/reference/actuator/endpoints.html) for the
+underlying mechanism and available JVM/HTTP metrics. Custom Torch-specific metrics (job/batch timings) may
+be added over time.
 
-See [Spring documentation](https://docs.spring.io/spring-boot/reference/actuator/endpoints.html)
+A minimal Prometheus scrape config:
 
-Custom metrics might be added with time.
+```yaml
+scrape_configs:
+- job_name: 'torch'
+  metrics_path: '/actuator/prometheus'
+  static_configs:
+  - targets: [ 'localhost:8086' ]
+```
 
-For an example setup see [application-test.yml](https://github.com/medizininformatik-initiative/torch/blob/main/src/test/resources/application-test.yml)
-**Note**: Be Careful with exposing these endpoints outside
+**Note:** the endpoint has no authentication in front of it — restrict access at the network or
+infrastructure layer (e.g. bind the port to an internal network only). Never expose it directly on a
+public interface.
 
 ## Setting up SSL Certificates
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,6 +56,11 @@ logging:
     de.medizininformatikinitiative.torch: ${LOG_LEVEL:info}
     ca.uhn.fhir: error
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
 
 spring:
   profiles:


### PR DESCRIPTION
## Summary
- Enable `/actuator/prometheus` for real deployments via `management.endpoints.web.exposure.include: health,info,prometheus` in `application.yml` (previously only enabled under the `test` profile).
- Rewrite the existing (stale) `## Monitoring` section in `docs/configuration.md` with the concrete endpoint path and a scrape-config example.

Follows the "Blaze minimal" approach discussed in #1155: no bundled Prometheus/Grafana compose stack, no app-level auth on `/actuator` — protected by network placement, not by the application. Blaze's own metrics setup is a separate concern and out of scope here.

Refs #1155 — the "custom torch-specific metrics" open question in that issue is intentionally out of scope here and left open for follow-up.

## Test plan
- [x] `PrometheusEndpointIT` passes (informational only — it runs under the `test` profile, which already had its own exposure config, so it doesn't cover this change).
- [x] Verified against the real (non-test) profile: `docker compose up -d --build torch && curl localhost:8086/actuator/prometheus` returns real metrics; startup log shows `Exposing 3 endpoints beneath base path '/actuator'`.