### PR TITLE
Extract Consent Source Data and Encounter Metadata Separately

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/torch/consent/ConsentAdjuster.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/consent/ConsentAdjuster.java
@@ -92,6 +92,7 @@ public class ConsentAdjuster {
                 .flatMap(encounter -> {
                     try {
                         String patientId = ResourceUtils.patientId(encounter);
+                        batch.diagnostics().consentAudit().add(patientId, ConsentAuditMinimizer.minimize(encounter));
                         return Mono.just(Tuples.of(patientId, encounter));
                     } catch (PatientIdNotFoundException e) {
                         logger.warn("Skipping encounter without patient ID: {}", encounter.getId());

--- a/src/main/java/de/medizininformatikinitiative/torch/consent/ConsentAuditMinimizer.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/consent/ConsentAuditMinimizer.java
@@ -1,0 +1,49 @@
+package de.medizininformatikinitiative.torch.consent;
+
+import org.hl7.fhir.r4.model.Consent;
+import org.hl7.fhir.r4.model.Encounter;
+import org.hl7.fhir.r4.model.Meta;
+
+/**
+ * Reduces fetched Consent/Encounter resources to the minimum fields needed to recalculate
+ * consent time windows, for use in the consent audit trail.
+ *
+ * @see de.medizininformatikinitiative.torch.diagnostics.ConsentAudit
+ */
+public class ConsentAuditMinimizer {
+
+    private ConsentAuditMinimizer() {
+    }
+
+    /**
+     * Reduces a Consent resource to id, meta.profile, patient, provision, dateTime and status.
+     */
+    public static Consent minimize(Consent source) {
+        Consent minimized = new Consent();
+        minimized.setId(source.getIdPart());
+        minimized.setMeta(minimizedMeta(source.getMeta()));
+        minimized.setPatient(source.getPatient());
+        minimized.setProvision(source.getProvision());
+        minimized.setDateTimeElement(source.getDateTimeElement());
+        minimized.setStatus(source.getStatus());
+        return minimized;
+    }
+
+    /**
+     * Reduces an Encounter resource to id, meta.profile, subject and period.
+     */
+    public static Encounter minimize(Encounter source) {
+        Encounter minimized = new Encounter();
+        minimized.setId(source.getIdPart());
+        minimized.setMeta(minimizedMeta(source.getMeta()));
+        minimized.setSubject(source.getSubject());
+        minimized.setPeriod(source.getPeriod());
+        return minimized;
+    }
+
+    private static Meta minimizedMeta(Meta source) {
+        Meta meta = new Meta();
+        source.getProfile().forEach(profile -> meta.addProfile(profile.getValue()));
+        return meta;
+    }
+}

--- a/src/main/java/de/medizininformatikinitiative/torch/consent/ConsentFetcher.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/consent/ConsentFetcher.java
@@ -77,6 +77,7 @@ public class ConsentFetcher {
                 .concatMap(consent -> {
                     try {
                         String patientId = ResourceUtils.patientId(consent);
+                        batch.diagnostics().consentAudit().add(patientId, ConsentAuditMinimizer.minimize(consent));
                         DateTimeType consentTime = consent.getDateTimeElement();
                         if (consentTime.isEmpty()) {
                             logger.warn("Skipping consent resource {} due to missing consent date", consent.getId());

--- a/src/main/java/de/medizininformatikinitiative/torch/diagnostics/BatchDiagnostics.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/diagnostics/BatchDiagnostics.java
@@ -8,27 +8,29 @@ import static java.util.Objects.requireNonNull;
  *
  * @param batchExclusions   the exclusion events happening during processing
  * @param batchDetails      other measurements recorded during processing
+ * @param consentAudit      the Consent/Encounter resources used to calculate consent, for traceability
  */
-public record BatchDiagnostics(BatchExclusions batchExclusions, BatchDetails batchDetails) {
+public record BatchDiagnostics(BatchExclusions batchExclusions, BatchDetails batchDetails, ConsentAudit consentAudit) {
 
     public BatchDiagnostics {
         requireNonNull(batchDetails);
         requireNonNull(batchExclusions);
+        requireNonNull(consentAudit);
     }
 
     public static BatchDiagnostics empty() {
-        return new BatchDiagnostics(BatchExclusions.empty(), BatchDetails.empty());
+        return new BatchDiagnostics(BatchExclusions.empty(), BatchDetails.empty(), ConsentAudit.empty());
     }
 
     public BatchDiagnostics setFinalPatientCount(int numFinalPatients) {
-        return new BatchDiagnostics(batchExclusions, batchDetails.setFinalPatientCount(numFinalPatients));
+        return new BatchDiagnostics(batchExclusions, batchDetails.setFinalPatientCount(numFinalPatients), consentAudit);
     }
 
     public BatchDiagnostics setNumCohortPatients(int numCohortPatients) {
-        return new BatchDiagnostics(batchExclusions, batchDetails.setNumCohortPatients(numCohortPatients));
+        return new BatchDiagnostics(batchExclusions, batchDetails.setNumCohortPatients(numCohortPatients), consentAudit);
     }
 
     public BatchDiagnostics setBatchDetails(BatchDetails newBatchDetails) {
-        return new BatchDiagnostics(batchExclusions, newBatchDetails);
+        return new BatchDiagnostics(batchExclusions, newBatchDetails, consentAudit);
     }
 }

--- a/src/main/java/de/medizininformatikinitiative/torch/diagnostics/ConsentAudit.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/diagnostics/ConsentAudit.java
@@ -1,0 +1,66 @@
+package de.medizininformatikinitiative.torch.diagnostics;
+
+import org.hl7.fhir.r4.model.Resource;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Collects the minimized Consent/Encounter resources used to calculate a batch's patient
+ * consent time windows, for later independent audit and recalculation.
+ * <p>
+ * Populated during consent fetching regardless of whether the batch ultimately succeeds or
+ * is skipped for lack of consent, so entries survive a
+ * {@link de.medizininformatikinitiative.torch.exceptions.ConsentViolatedException}.
+ * <p>
+ * Not a record to avoid mutations of the queue without the dedicated methods.
+ */
+public class ConsentAudit {
+
+    private final Queue<ConsentAuditEntry> entries;
+
+    public ConsentAudit(Queue<ConsentAuditEntry> entries) {
+        this.entries = requireNonNull(entries);
+    }
+
+    public static ConsentAudit empty() {
+        return new ConsentAudit(new ConcurrentLinkedQueue<>());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof ConsentAudit other)) {
+            return false;
+        }
+        return this.entries().equals(other.entries());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(entries());
+    }
+
+    public void add(String patientId, Resource resource) {
+        entries.add(new ConsentAuditEntry(patientId, resource));
+    }
+
+    /**
+     * Creates a copy of the currently collected entries.
+     *
+     * @return a list of the consent audit entries.
+     */
+    public List<ConsentAuditEntry> entries() {
+        return entries.stream().toList();
+    }
+
+    public boolean isEmpty() {
+        return entries.isEmpty();
+    }
+}

--- a/src/main/java/de/medizininformatikinitiative/torch/diagnostics/ConsentAuditEntry.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/diagnostics/ConsentAuditEntry.java
@@ -1,0 +1,20 @@
+package de.medizininformatikinitiative.torch.diagnostics;
+
+import org.hl7.fhir.r4.model.Resource;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A single minimized Consent or Encounter resource used to calculate a patient's consent
+ * time window, kept for traceability.
+ *
+ * @param patientId the patient the resource was fetched for
+ * @param resource  the minimized Consent or Encounter resource
+ */
+public record ConsentAuditEntry(String patientId, Resource resource) {
+
+    public ConsentAuditEntry {
+        requireNonNull(patientId);
+        requireNonNull(resource);
+    }
+}

--- a/src/main/java/de/medizininformatikinitiative/torch/service/ExtractDataService.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/service/ExtractDataService.java
@@ -3,6 +3,7 @@ package de.medizininformatikinitiative.torch.service;
 import de.medizininformatikinitiative.torch.config.TorchProperties;
 import de.medizininformatikinitiative.torch.consent.ConsentHandler;
 import de.medizininformatikinitiative.torch.diagnostics.BatchDiagnostics;
+import de.medizininformatikinitiative.torch.diagnostics.ConsentAudit;
 import de.medizininformatikinitiative.torch.diagnostics.PipelineStage;
 import de.medizininformatikinitiative.torch.diagnostics.exclusions.BatchExclusions;
 import de.medizininformatikinitiative.torch.diagnostics.exclusions.PatientExclusionStage;
@@ -150,18 +151,20 @@ public class ExtractDataService {
 
         return batchWithConsent
                 .flatMap(bwc -> processBatchAfterConsent(bwc, jobId, groupsToProcess, batchState))
-                .switchIfEmpty(Mono.fromSupplier(() ->
-                    new BatchResult(
-                            jobId,
-                            batch.batchId(),
-                            batchState.skip(),
-                            Optional.empty(),
-                            Optional.of(batch.diagnostics()),
-                            List.of(Issue.simple(
-                                    Severity.WARNING,
-                                    "Batch " + selection.batchState().batchId() + " skipped because of no consenting patients"
-                            ))
-                    )));
+                .switchIfEmpty(writeConsentAudit(jobId.toString(), batch.batchId(), batch.diagnostics().consentAudit())
+                        .subscribeOn(Schedulers.boundedElastic())
+                        .then(Mono.fromSupplier(() ->
+                            new BatchResult(
+                                    jobId,
+                                    batch.batchId(),
+                                    batchState.skip(),
+                                    Optional.empty(),
+                                    Optional.of(batch.diagnostics()),
+                                    List.of(Issue.simple(
+                                            Severity.WARNING,
+                                            "Batch " + selection.batchState().batchId() + " skipped because of no consenting patients"
+                                    ))
+                            ))));
     }
 
     private <T> Mono<T> executeAndMeasureAsync(PipelineStage stage, BatchDiagnostics diagnostics, Supplier<Mono<T>> f) {
@@ -229,6 +232,7 @@ public class ExtractDataService {
                 .doOnNext(__ -> logger.debug("Batch finished extraction {}", batchId))
                 .flatMap(extractedBatch ->
                         writeBatch(jobId.toString(), extractedBatch)
+                                .then(writeConsentAudit(jobId.toString(), batchId, batch.diagnostics().consentAudit()))
                                 .subscribeOn(Schedulers.boundedElastic())
                                 .thenReturn(extractedBatch)
                 )
@@ -322,6 +326,28 @@ public class ExtractDataService {
         return Mono.defer(() -> {
             try {
                 resultFileManager.saveBatchToNDJSON(jobID, batch);
+                return Mono.empty();
+            } catch (IOException e) {
+                return Mono.error(e);
+            }
+        });
+    }
+
+    /**
+     * Persists a batch's consent audit trail as NDJSON, if not empty.
+     * <p>
+     * Called for both finished and skipped batches, so consent decisions stay traceable even
+     * when a batch has no consenting patients.
+     *
+     * @param jobID        owning job id (directory key)
+     * @param batchId      batch id (also used as filename key)
+     * @param consentAudit collected consent audit entries for the batch
+     * @return completion signal; emits error if writing fails
+     */
+    Mono<Void> writeConsentAudit(String jobID, UUID batchId, ConsentAudit consentAudit) {
+        return Mono.defer(() -> {
+            try {
+                resultFileManager.saveConsentBatchToNDJSON(jobID, batchId, consentAudit);
                 return Mono.empty();
             } catch (IOException e) {
                 return Mono.error(e);

--- a/src/main/java/de/medizininformatikinitiative/torch/taskhandling/JobTaskMapper.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/taskhandling/JobTaskMapper.java
@@ -1,21 +1,38 @@
 package de.medizininformatikinitiative.torch.taskhandling;
 
+import de.medizininformatikinitiative.torch.config.TorchProperties;
 import de.medizininformatikinitiative.torch.jobhandling.Job;
 import de.medizininformatikinitiative.torch.jobhandling.JobPriority;
 import de.medizininformatikinitiative.torch.jobhandling.JobStatus;
+import de.medizininformatikinitiative.torch.util.ResultFileManager;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Period;
 import org.hl7.fhir.r4.model.Task;
+import org.hl7.fhir.r4.model.UrlType;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
+
+import static java.util.Objects.requireNonNull;
 
 @Component
 public class JobTaskMapper {
 
     private static final String TORCH_STATUS_SYSTEM =
             "https://medizininformatik-initiative.de/torch/job-status";
+
+    private final ResultFileManager resultFileManager;
+    private final String fileServerName;
+
+    /**
+     * @param resultFileManager used to check which batches have a consent audit trail on disk
+     * @param properties        provides the file server base URL for building consent audit download links
+     */
+    public JobTaskMapper(ResultFileManager resultFileManager, TorchProperties properties) {
+        this.resultFileManager = requireNonNull(resultFileManager);
+        this.fileServerName = properties.output().file().server().url();
+    }
 
     public Task toFhirTask(Job job) {
         Task task = new Task();
@@ -48,6 +65,17 @@ public class JobTaskMapper {
         task.setExecutionPeriod(period);
 
         task.setDescription("TORCH Job " + job.id());
+
+        if (job.status() == JobStatus.COMPLETED) {
+            job.batches().keySet().forEach(batchId -> {
+                if (resultFileManager.consentAuditExists(job.id().toString(), batchId)) {
+                    Task.TaskOutputComponent output = new Task.TaskOutputComponent();
+                    output.setType(new CodeableConcept().setText("Consent audit NDJSON"));
+                    output.setValue(new UrlType(fileServerName + "/" + job.id() + "/" + batchId + ResultFileManager.CONSENT_NDJSON));
+                    task.addOutput(output);
+                }
+            });
+        }
 
         return task;
     }

--- a/src/main/java/de/medizininformatikinitiative/torch/util/ResultFileManager.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/util/ResultFileManager.java
@@ -2,9 +2,13 @@ package de.medizininformatikinitiative.torch.util;
 
 
 import ca.uhn.fhir.context.FhirContext;
+import de.medizininformatikinitiative.torch.diagnostics.ConsentAudit;
+import de.medizininformatikinitiative.torch.diagnostics.ConsentAuditEntry;
 import de.medizininformatikinitiative.torch.jobhandling.FileIo;
 import de.medizininformatikinitiative.torch.model.extraction.ExtractionPatientBatch;
 import de.medizininformatikinitiative.torch.model.extraction.ExtractionResourceBundle;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,6 +17,10 @@ import java.io.IOException;
 import java.io.Writer;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
 
@@ -27,6 +35,7 @@ public class ResultFileManager {
 
     private static final Logger logger = LoggerFactory.getLogger(ResultFileManager.class);
     private static final String NDJSON = ".ndjson";
+    public static final String CONSENT_NDJSON = "_consent" + NDJSON;
 
     private final Path resultsDirPath;
     private final FhirContext fhirContext;
@@ -53,6 +62,17 @@ public class ResultFileManager {
      */
     public Path getJobDirectory(String jobId) {
         return resultsDirPath.resolve(jobId);
+    }
+
+    /**
+     * Checks whether a batch's consent audit trail was written for the given batch.
+     *
+     * @param jobId   the job id.
+     * @param batchId the batch id.
+     * @return true if {@code {batchId}_consent.ndjson} exists for this job.
+     */
+    public boolean consentAuditExists(String jobId, UUID batchId) {
+        return fileIo.exists(getJobDirectory(jobId).resolve(batchId + CONSENT_NDJSON));
     }
 
     /**
@@ -83,6 +103,58 @@ public class ResultFileManager {
 
         try (BufferedWriter out = fileIo.newBufferedWriter(tmp)) {
             batch.writeToFhirBundles(fhirContext, out, jobId);
+        }
+        fileIo.atomicMove(tmp, target);
+    }
+
+    /**
+     * Writes a batch's consent audit trail to an NDJSON file.
+     * <p>
+     * Each line contains one FHIR collection {@link Bundle} per patient, holding the minimized
+     * Consent/Encounter resources used to calculate that patient's consent time window.
+     * Written independently of whether the batch itself was finished or skipped, so consent
+     * decisions stay traceable even for batches with no consenting patients.
+     * Empty audits are ignored.
+     *
+     * @param jobId        the job id.
+     * @param batchId      the batch id.
+     * @param consentAudit the collected consent audit entries for the batch.
+     * @throws IOException if the output directory cannot be created or the file cannot be written.
+     */
+    public void saveConsentBatchToNDJSON(String jobId, UUID batchId, ConsentAudit consentAudit) throws IOException {
+        requireNonNull(jobId);
+        requireNonNull(batchId);
+        requireNonNull(consentAudit);
+
+        if (consentAudit.isEmpty()) {
+            logger.trace("Attempted to save empty consent audit for job {}, batch {}", jobId, batchId);
+            return;
+        }
+
+        Path resultDir = getJobDirectory(jobId);
+        fileIo.createDirectories(resultDir);
+
+        Path target = resultDir.resolve(batchId + CONSENT_NDJSON);
+        Path tmp = resultDir.resolve(batchId + CONSENT_NDJSON + ".tmp");
+        logger.debug("Writing consent audit for batch {} of job {} to {}", batchId, jobId, target);
+
+        Map<String, List<Resource>> resourcesByPatient = consentAudit.entries().stream()
+                .collect(Collectors.groupingBy(ConsentAuditEntry::patientId,
+                        Collectors.mapping(ConsentAuditEntry::resource, Collectors.toList())));
+
+        try (BufferedWriter out = fileIo.newBufferedWriter(tmp)) {
+            for (List<Resource> resources : resourcesByPatient.values()) {
+                Bundle bundle = new Bundle();
+                bundle.setType(Bundle.BundleType.COLLECTION);
+                bundle.setId(UUID.randomUUID().toString());
+                for (Resource resource : resources) {
+                    Bundle.BundleEntryComponent entry = new Bundle.BundleEntryComponent();
+                    entry.setResource(resource);
+                    bundle.addEntry(entry);
+                }
+                fhirContext.newJsonParser().setPrettyPrint(false).encodeResourceToWriter(bundle, out);
+                out.append("\n");
+            }
         }
         fileIo.atomicMove(tmp, target);
     }

--- a/src/test/java/de/medizininformatikinitiative/torch/consent/ConsentAdjusterTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/consent/ConsentAdjusterTest.java
@@ -133,6 +133,30 @@ class ConsentAdjusterUnitTest {
     }
 
     @Test
+    void fetchAndAdjust_capturesEncountersInAuditTrail() {
+        PatientBatch batch = new PatientBatch(List.of("patient1"));
+
+        Provision p1 = new Provision(new TermCode("s1", "code1"), Period.of(LocalDate.of(2025, 9, 10), LocalDate.of(2025, 9, 30)), true);
+        ConsentProvisions consent = new ConsentProvisions("patient1", null, List.of(p1));
+
+        Encounter e1 = createEncounter("patient1", LocalDate.of(2025, 9, 5), LocalDate.of(2025, 9, 15));
+        e1.setId("enc-1");
+
+        when(dataStore.search(any(Query.class), eq(Encounter.class)))
+                .thenReturn(Flux.just(e1));
+
+        StepVerifier.create(adjuster.fetchEncounterAndAdjustByEncounter(batch, Map.of("patient1", List.of(consent)), Set.of(new TermCode("s1", "code1"))))
+                .expectNextCount(1)
+                .verifyComplete();
+
+        assertThat(batch.diagnostics().consentAudit().entries()).singleElement().satisfies(entry -> {
+            assertThat(entry.patientId()).isEqualTo("patient1");
+            assertThat(entry.resource()).isInstanceOf(Encounter.class);
+            assertThat(entry.resource().getIdPart()).isEqualTo("enc-1");
+        });
+    }
+
+    @Test
     void testFetchAndAdjust_withMockedDataStore() {
         PatientBatch batch = new PatientBatch(List.of("patient1", "patient2"));
 

--- a/src/test/java/de/medizininformatikinitiative/torch/consent/ConsentAuditMinimizerTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/consent/ConsentAuditMinimizerTest.java
@@ -1,0 +1,71 @@
+package de.medizininformatikinitiative.torch.consent;
+
+import org.hl7.fhir.r4.model.CanonicalType;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Consent;
+import org.hl7.fhir.r4.model.DateTimeType;
+import org.hl7.fhir.r4.model.Encounter;
+import org.hl7.fhir.r4.model.Identifier;
+import org.hl7.fhir.r4.model.Meta;
+import org.hl7.fhir.r4.model.Period;
+import org.hl7.fhir.r4.model.Reference;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConsentAuditMinimizerTest {
+
+    @Test
+    void minimizeConsent_keepsOnlyRelevantFields() {
+        Consent source = new Consent();
+        source.setId("consent-1");
+        Meta meta = new Meta();
+        meta.addProfile("https://example.org/consent-profile");
+        meta.setVersionId("42");
+        source.setMeta(meta);
+        source.setPatient(new Reference("Patient/1"));
+        source.getProvision().setId("root-provision");
+        source.setDateTimeElement(new DateTimeType("2022-09-09T17:05:07+02:00"));
+        source.setStatus(Consent.ConsentState.ACTIVE);
+        source.addIdentifier(new Identifier().setValue("should-be-dropped"));
+
+        Consent minimized = ConsentAuditMinimizer.minimize(source);
+
+        assertThat(minimized.getIdPart()).isEqualTo("consent-1");
+        assertThat(minimized.getMeta().getProfile()).extracting(CanonicalType::getValue)
+                .containsExactly("https://example.org/consent-profile");
+        assertThat(minimized.getMeta().getVersionId()).isNullOrEmpty();
+        assertThat(minimized.getPatient().getReference()).isEqualTo("Patient/1");
+        assertThat(minimized.getProvision().getId()).isEqualTo("root-provision");
+        assertThat(minimized.getDateTimeElement().getValueAsString()).isEqualTo(source.getDateTimeElement().getValueAsString());
+        assertThat(minimized.getStatus()).isEqualTo(Consent.ConsentState.ACTIVE);
+        assertThat(minimized.getIdentifier()).isEmpty();
+    }
+
+    @Test
+    void minimizeEncounter_keepsOnlyRelevantFields() {
+        Encounter source = new Encounter();
+        source.setId("encounter-1");
+        Meta meta = new Meta();
+        meta.addProfile("https://example.org/encounter-profile");
+        source.setMeta(meta);
+        source.setSubject(new Reference("Patient/1"));
+        Period period = new Period();
+        period.setStartElement(new DateTimeType("2022-02-19T09:04:30+01:00"));
+        period.setEndElement(new DateTimeType("2022-02-19T12:15:00+01:00"));
+        source.setPeriod(period);
+        source.setType(List.of(new CodeableConcept().setText("should-be-dropped")));
+
+        Encounter minimized = ConsentAuditMinimizer.minimize(source);
+
+        assertThat(minimized.getIdPart()).isEqualTo("encounter-1");
+        assertThat(minimized.getMeta().getProfile()).extracting(CanonicalType::getValue)
+                .containsExactly("https://example.org/encounter-profile");
+        assertThat(minimized.getSubject().getReference()).isEqualTo("Patient/1");
+        assertThat(minimized.getPeriod().getStartElement().getValueAsString())
+                .isEqualTo(source.getPeriod().getStartElement().getValueAsString());
+        assertThat(minimized.getType()).isEmpty();
+    }
+}

--- a/src/test/java/de/medizininformatikinitiative/torch/consent/ConsentFetcherTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/consent/ConsentFetcherTest.java
@@ -141,6 +141,34 @@ class ConsentFetcherTest {
     }
 
     @Test
+    void capturesConsentInAuditTrailEvenWhenBatchIsSkipped() {
+        // consent with ACTIVE status but missing dateTime -> fetchConsentInfo errors out
+        Consent consent = new Consent();
+        consent.setStatus(Consent.ConsentState.ACTIVE);
+        consent.setId("cons-no-date");
+        consent.setDateTimeElement(new DateTimeType());
+
+        when(dataStore.search(any(), any())).thenReturn(Flux.just(consent));
+
+        PatientBatch batch = new PatientBatch(List.of("patient1"));
+
+        try (MockedStatic<ResourceUtils> mocked = mockStatic(ResourceUtils.class)) {
+            mocked.when(() -> ResourceUtils.patientId(consent)).thenReturn("patient1");
+
+            StepVerifier.create(consentFetcher.fetchConsentInfo(CODES, batch))
+                    .expectError(ConsentViolatedException.class)
+                    .verify();
+        }
+
+        // the audit entry must survive even though the whole batch ends up skipped
+        assertThat(batch.diagnostics().consentAudit().entries()).singleElement().satisfies(entry -> {
+            assertThat(entry.patientId()).isEqualTo("patient1");
+            assertThat(entry.resource()).isInstanceOf(Consent.class);
+            assertThat(entry.resource().getIdPart()).isEqualTo("cons-no-date");
+        });
+    }
+
+    @Test
     void failsWhenExtractProvisionsThrows() throws PatientIdNotFoundException, ConsentViolatedException {
         Consent consent = new Consent();
         consent.setStatus(Consent.ConsentState.ACTIVE);

--- a/src/test/java/de/medizininformatikinitiative/torch/diagnostics/DiagnosticsStoreTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/diagnostics/DiagnosticsStoreTest.java
@@ -63,7 +63,7 @@ class DiagnosticsStoreTest {
         batchExclusions_1.addMustHaveExclusionCore(GROUP_1, RESOURCE_1, ATTRIBUTE_1);
         batchExclusions_1.addReferenceNotFoundExclusionCore(GROUP_1, RESOURCE_1);
         batchExclusions_1.addPatientExclusion(PatientExclusionStage.DIRECT_LOAD, PATIENT_1);
-        return new BatchDiagnostics(batchExclusions_1, details_1);
+        return new BatchDiagnostics(batchExclusions_1, details_1, ConsentAudit.empty());
     }
 
     static BatchDiagnostics createDiagnostics_2() {
@@ -76,7 +76,7 @@ class DiagnosticsStoreTest {
         batchExclusions_2.addMustHaveExclusionCore(GROUP_2, RESOURCE_2, ATTRIBUTE_2);
         batchExclusions_2.addReferenceNotFoundExclusionCore(GROUP_2, RESOURCE_2);
         batchExclusions_2.addPatientExclusion(PatientExclusionStage.DIRECT_LOAD, PATIENT_2);
-        return new BatchDiagnostics(batchExclusions_2, details_2);
+        return new BatchDiagnostics(batchExclusions_2, details_2, ConsentAudit.empty());
     }
 
     @Test

--- a/src/test/java/de/medizininformatikinitiative/torch/rest/TaskControllerTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/rest/TaskControllerTest.java
@@ -2,6 +2,7 @@ package de.medizininformatikinitiative.torch.rest;
 
 import ca.uhn.fhir.context.FhirContext;
 import de.medizininformatikinitiative.torch.TestUtils;
+import de.medizininformatikinitiative.torch.config.TorchProperties;
 import de.medizininformatikinitiative.torch.exceptions.JobNotFoundException;
 import de.medizininformatikinitiative.torch.exceptions.StateConflictException;
 import de.medizininformatikinitiative.torch.exceptions.VersionConflictException;
@@ -11,6 +12,7 @@ import de.medizininformatikinitiative.torch.jobhandling.JobPriority;
 import de.medizininformatikinitiative.torch.jobhandling.JobStatus;
 import de.medizininformatikinitiative.torch.service.JobPersistenceService;
 import de.medizininformatikinitiative.torch.taskhandling.JobTaskMapper;
+import de.medizininformatikinitiative.torch.util.ResultFileManager;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.Task;
@@ -38,8 +40,25 @@ class TaskControllerTest {
 
     static final JobParameters EMPTY_PARAMETERS = TestUtils.emptyJobParams();
 
+    private static final TorchProperties PROPERTIES = new TorchProperties(
+            new TorchProperties.Base("http://base-url"),
+            new TorchProperties.Output(new TorchProperties.Output.File(new TorchProperties.Output.File.Server("http://server-url"))),
+            new TorchProperties.Profile("/profile-dir"),
+            new TorchProperties.Mapping("typeToConsent"),
+            new TorchProperties.Flare(null, null),
+            new TorchProperties.Results("BASE_DIR"),
+            10, 5, 100,
+            "mappingsFile", "conceptTreeFile", "dseMappingTreeFile",
+            "search-parameters.json",
+            true,
+            false
+    );
+
     @Mock
     JobPersistenceService persistence;
+
+    @Mock
+    ResultFileManager resultFileManager;
 
     FhirContext fhirContext;
     JobTaskMapper jobTaskMapper;
@@ -49,7 +68,7 @@ class TaskControllerTest {
     @BeforeEach
     void setUp() {
         fhirContext = FhirContext.forR4();
-        jobTaskMapper = new JobTaskMapper();
+        jobTaskMapper = new JobTaskMapper(resultFileManager, PROPERTIES);
         controller = new TaskController(fhirContext, persistence, jobTaskMapper);
         client = WebTestClient.bindToRouterFunction(controller.taskRouter()).build();
     }

--- a/src/test/java/de/medizininformatikinitiative/torch/service/ExtractDataServiceTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/service/ExtractDataServiceTest.java
@@ -3,6 +3,7 @@ package de.medizininformatikinitiative.torch.service;
 import de.medizininformatikinitiative.torch.config.TorchProperties;
 import de.medizininformatikinitiative.torch.consent.ConsentHandler;
 import de.medizininformatikinitiative.torch.diagnostics.BatchDiagnostics;
+import de.medizininformatikinitiative.torch.diagnostics.ConsentAudit;
 import de.medizininformatikinitiative.torch.diagnostics.exclusions.ResourceExclusionEvent;
 import de.medizininformatikinitiative.torch.diagnostics.exclusions.ResourceExclusionReason;
 import de.medizininformatikinitiative.torch.exceptions.ConsentViolatedException;
@@ -354,7 +355,7 @@ class ExtractDataServiceTest {
         }
 
         @Test
-        void processBatch_whenConsentViolated_switchIfEmptyReturnsSkippedResult() {
+        void processBatch_whenConsentViolated_switchIfEmptyReturnsSkippedResult() throws Exception {
             UUID jobId = UUID.randomUUID();
             UUID batchId = UUID.randomUUID();
 
@@ -399,6 +400,7 @@ class ExtractDataServiceTest {
                     .verifyComplete();
 
             verifyNoInteractions(directResourceLoader, referenceResolver, batchCopierRedacter, batchToCoreWriter);
+            verify(resultFileManager).saveConsentBatchToNDJSON(eq(jobId.toString()), eq(batchId), any());
         }
 
         @Test
@@ -511,6 +513,31 @@ class ExtractDataServiceTest {
                     .verifyErrorSatisfies(e -> {
                         assertThat(e).isInstanceOf(IOException.class);
                         assertThat(e).hasMessageContaining("no space");
+                    });
+        }
+
+        @Test
+        void writeConsentAudit_success_completes() throws Exception {
+            UUID batchId = UUID.randomUUID();
+            ConsentAudit audit = ConsentAudit.empty();
+
+            StepVerifier.create(service.writeConsentAudit("job", batchId, audit))
+                    .verifyComplete();
+
+            verify(resultFileManager).saveConsentBatchToNDJSON("job", batchId, audit);
+        }
+
+        @Test
+        void writeConsentAudit_whenIOException_emitsError() throws Exception {
+            UUID batchId = UUID.randomUUID();
+            ConsentAudit audit = ConsentAudit.empty();
+            doThrow(new IOException("disk full"))
+                    .when(resultFileManager).saveConsentBatchToNDJSON("job", batchId, audit);
+
+            StepVerifier.create(service.writeConsentAudit("job", batchId, audit))
+                    .verifyErrorSatisfies(e -> {
+                        assertThat(e).isInstanceOf(IOException.class);
+                        assertThat(e).hasMessageContaining("disk full");
                     });
         }
     }

--- a/src/test/java/de/medizininformatikinitiative/torch/service/JobPersistenceServiceTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/service/JobPersistenceServiceTest.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.opencsv.exceptions.CsvValidationException;
 import de.medizininformatikinitiative.torch.diagnostics.BatchDetails;
 import de.medizininformatikinitiative.torch.diagnostics.BatchDiagnostics;
+import de.medizininformatikinitiative.torch.diagnostics.ConsentAudit;
 import de.medizininformatikinitiative.torch.diagnostics.DiagnosticsStore;
 import de.medizininformatikinitiative.torch.diagnostics.exclusions.BatchExclusions;
 import de.medizininformatikinitiative.torch.diagnostics.exclusions.PatientExclusionStage;
@@ -1152,7 +1153,7 @@ class JobPersistenceServiceTest {
             batchExclusions_1.addMustHaveExclusionCore(GROUP_1, RESOURCE_1, ATTRIBUTE_1);
             batchExclusions_1.addReferenceNotFoundExclusionCore(GROUP_1, RESOURCE_1);
             batchExclusions_1.addPatientExclusion(PatientExclusionStage.DIRECT_LOAD, PATIENT_1);
-            return new BatchDiagnostics(batchExclusions_1, details_1);
+            return new BatchDiagnostics(batchExclusions_1, details_1, ConsentAudit.empty());
         }
 
         static BatchDiagnostics createDiagnostics_2() {
@@ -1165,7 +1166,7 @@ class JobPersistenceServiceTest {
             batchExclusions_2.addMustHaveExclusionCore(GROUP_2, RESOURCE_2, ATTRIBUTE_2);
             batchExclusions_2.addReferenceNotFoundExclusionCore(GROUP_2, RESOURCE_2);
             batchExclusions_2.addPatientExclusion(PatientExclusionStage.DIRECT_LOAD, PATIENT_2);
-            return new BatchDiagnostics(batchExclusions_2, details_2);
+            return new BatchDiagnostics(batchExclusions_2, details_2, ConsentAudit.empty());
         }
 
         static BatchResult createBatchResult(BatchDiagnostics diagnostics, UUID jobId, UUID batchId) {
@@ -1185,7 +1186,7 @@ class JobPersistenceServiceTest {
             var details = new BatchDetails(Map.of(), 2, 1);
             var batchExclusions = BatchExclusions.empty();
             batchExclusions.addPatientExclusion(PatientExclusionStage.DIRECT_LOAD, PATIENT_1);
-            var diagnostics = new BatchDiagnostics(batchExclusions, details);
+            var diagnostics = new BatchDiagnostics(batchExclusions, details, ConsentAudit.empty());
 
             persistenceService.selectNextInternal(jobId);
             persistenceService.onCohortSuccess(jobId, List.of(), Optional.empty());
@@ -1204,7 +1205,7 @@ class JobPersistenceServiceTest {
                     Optional.empty()), List.of(), "");
 
             var details = new BatchDetails(Map.of(), 2, 1);
-            var diagnostics = new BatchDiagnostics(BatchExclusions.empty(), details);
+            var diagnostics = new BatchDiagnostics(BatchExclusions.empty(), details, ConsentAudit.empty());
 
             persistenceService.selectNextInternal(jobId);
             persistenceService.onCohortSuccess(jobId, List.of(), Optional.empty());

--- a/src/test/java/de/medizininformatikinitiative/torch/taskhandling/JobTaskMapperTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/taskhandling/JobTaskMapperTest.java
@@ -1,10 +1,16 @@
 package de.medizininformatikinitiative.torch.taskhandling;
 
 import de.medizininformatikinitiative.torch.TestUtils;
+import de.medizininformatikinitiative.torch.config.TorchProperties;
+import de.medizininformatikinitiative.torch.jobhandling.BatchState;
 import de.medizininformatikinitiative.torch.jobhandling.Job;
 import de.medizininformatikinitiative.torch.jobhandling.JobPriority;
 import de.medizininformatikinitiative.torch.jobhandling.JobStatus;
+import de.medizininformatikinitiative.torch.jobhandling.workunit.WorkUnitState;
+import de.medizininformatikinitiative.torch.jobhandling.workunit.WorkUnitStatus;
+import de.medizininformatikinitiative.torch.util.ResultFileManager;
 import org.hl7.fhir.r4.model.Task;
+import org.hl7.fhir.r4.model.UrlType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -15,13 +21,31 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.of;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 class JobTaskMapperTest {
 
     private static final String SYSTEM =
             "https://medizininformatik-initiative.de/torch/job-status";
 
-    private final JobTaskMapper mapper = new JobTaskMapper();
+    private static final TorchProperties PROPERTIES = new TorchProperties(
+            new TorchProperties.Base("http://base-url"),
+            new TorchProperties.Output(new TorchProperties.Output.File(new TorchProperties.Output.File.Server("http://server-url"))),
+            new TorchProperties.Profile("/profile-dir"),
+            new TorchProperties.Mapping("typeToConsent"),
+            new TorchProperties.Flare(null, null),
+            new TorchProperties.Results("BASE_DIR"),
+            10, 5, 100,
+            "mappingsFile", "conceptTreeFile", "dseMappingTreeFile",
+            "search-parameters.json",
+            true,
+            false
+    );
+
+    private final ResultFileManager resultFileManager = mock(ResultFileManager.class);
+    private final JobTaskMapper mapper = new JobTaskMapper(resultFileManager, PROPERTIES);
 
     private static Stream<org.junit.jupiter.params.provider.Arguments> statusMappings() {
         return Stream.of(
@@ -111,5 +135,51 @@ class JobTaskMapperTest {
 
         assertThat(t.getExecutionPeriod().getEnd())
                 .isEqualTo(Date.from(job.finishedAt().orElseThrow()));
+    }
+
+    @Test
+    void addsConsentAuditOutput_whenJobCompletedAndAuditFileExists() {
+        UUID id = UUID.randomUUID();
+        UUID batchId = UUID.randomUUID();
+        Job job = job(id, JobStatus.COMPLETED, JobPriority.NORMAL, 1)
+                .withBatchState(new BatchState(batchId, WorkUnitState.initNow().finishNow(WorkUnitStatus.FINISHED)));
+
+        when(resultFileManager.consentAuditExists(id.toString(), batchId)).thenReturn(true);
+
+        Task t = mapper.toFhirTask(job);
+
+        assertThat(t.getOutput()).singleElement().satisfies(output -> {
+            assertThat(output.getType().getText()).isEqualTo("Consent audit NDJSON");
+            assertThat(output.getValue()).isInstanceOf(UrlType.class);
+            assertThat(((UrlType) output.getValue()).getValue())
+                    .isEqualTo("http://server-url/" + id + "/" + batchId + "_consent.ndjson");
+        });
+    }
+
+    @Test
+    void omitsConsentAuditOutput_whenAuditFileMissing() {
+        UUID id = UUID.randomUUID();
+        UUID batchId = UUID.randomUUID();
+        Job job = job(id, JobStatus.COMPLETED, JobPriority.NORMAL, 1)
+                .withBatchState(new BatchState(batchId, WorkUnitState.initNow().finishNow(WorkUnitStatus.SKIPPED)));
+
+        when(resultFileManager.consentAuditExists(id.toString(), batchId)).thenReturn(false);
+
+        Task t = mapper.toFhirTask(job);
+
+        assertThat(t.getOutput()).isEmpty();
+    }
+
+    @Test
+    void omitsConsentAuditOutput_whenJobNotCompleted() {
+        UUID id = UUID.randomUUID();
+        UUID batchId = UUID.randomUUID();
+        Job job = job(id, JobStatus.RUNNING_PROCESS_BATCH, JobPriority.NORMAL, 1)
+                .withBatchState(new BatchState(batchId, WorkUnitState.initNow().finishNow(WorkUnitStatus.FINISHED)));
+
+        Task t = mapper.toFhirTask(job);
+
+        assertThat(t.getOutput()).isEmpty();
+        verifyNoInteractions(resultFileManager);
     }
 }

--- a/src/test/java/de/medizininformatikinitiative/torch/util/ResultFileManagerTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/util/ResultFileManagerTest.java
@@ -1,9 +1,13 @@
 package de.medizininformatikinitiative.torch.util;
 
 import ca.uhn.fhir.context.FhirContext;
+import de.medizininformatikinitiative.torch.diagnostics.ConsentAudit;
 import de.medizininformatikinitiative.torch.jobhandling.DefaultFileIO;
 import de.medizininformatikinitiative.torch.model.extraction.ExtractionPatientBatch;
 import de.medizininformatikinitiative.torch.model.extraction.ExtractionResourceBundle;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Consent;
+import org.hl7.fhir.r4.model.Encounter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -11,6 +15,7 @@ import java.io.IOException;
 import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -104,5 +109,69 @@ class ResultFileManagerTest {
         Path ndjson = tempDir.resolve("jobY").resolve(batchId + ".ndjson");
         assertThat(ndjson).exists();
         assertThat(Files.readAllLines(ndjson)).containsExactly("{\"resourceType\":\"Bundle\"}");
+    }
+
+    @Test
+    void saveConsentBatchToNDJSON_skipsWhenAuditEmpty() throws IOException {
+        FhirContext ctx = FhirContext.forR4();
+        ResultFileManager manager = new ResultFileManager(tempDir.toString(), ctx, new DefaultFileIO());
+
+        UUID batchId = UUID.randomUUID();
+        manager.saveConsentBatchToNDJSON("jobZ", batchId, ConsentAudit.empty());
+
+        Path ndjson = tempDir.resolve("jobZ").resolve(batchId + "_consent.ndjson");
+        assertThat(ndjson).doesNotExist();
+    }
+
+    @Test
+    void saveConsentBatchToNDJSON_writesOneCollectionBundlePerPatient() throws IOException {
+        FhirContext ctx = FhirContext.forR4();
+        ResultFileManager manager = new ResultFileManager(tempDir.toString(), ctx, new DefaultFileIO());
+
+        UUID batchId = UUID.randomUUID();
+        ConsentAudit audit = ConsentAudit.empty();
+
+        Consent consent1 = new Consent();
+        consent1.setId("consent-1");
+        Encounter encounter1 = new Encounter();
+        encounter1.setId("encounter-1");
+        audit.add("patient-1", consent1);
+        audit.add("patient-1", encounter1);
+
+        Consent consent2 = new Consent();
+        consent2.setId("consent-2");
+        audit.add("patient-2", consent2);
+
+        manager.saveConsentBatchToNDJSON("jobZ", batchId, audit);
+
+        Path ndjson = tempDir.resolve("jobZ").resolve(batchId + "_consent.ndjson");
+        assertThat(ndjson).exists();
+
+        List<String> lines = Files.readAllLines(ndjson);
+        assertThat(lines).hasSize(2);
+
+        List<Bundle> bundles = lines.stream()
+                .map(line -> ctx.newJsonParser().parseResource(Bundle.class, line))
+                .toList();
+
+        assertThat(bundles).allMatch(b -> b.getType() == Bundle.BundleType.COLLECTION);
+        assertThat(bundles.stream().map(b -> b.getEntry().size()).sorted().toList())
+                .containsExactly(1, 2);
+    }
+
+    @Test
+    void consentAuditExists_trueAfterWrite_falseOtherwise() throws IOException {
+        FhirContext ctx = FhirContext.forR4();
+        ResultFileManager manager = new ResultFileManager(tempDir.toString(), ctx, new DefaultFileIO());
+
+        UUID writtenBatchId = UUID.randomUUID();
+        UUID missingBatchId = UUID.randomUUID();
+        ConsentAudit audit = ConsentAudit.empty();
+        audit.add("patient-1", new Consent().setId("consent-1"));
+
+        manager.saveConsentBatchToNDJSON("jobZ", writtenBatchId, audit);
+
+        assertThat(manager.consentAuditExists("jobZ", writtenBatchId)).isTrue();
+        assertThat(manager.consentAuditExists("jobZ", missingBatchId)).isFalse();
     }
 }


### PR DESCRIPTION
## Summary
- Captures the minimized `Consent`/`Encounter` resources used to calculate each patient's consent time window during batch processing (survives batches that end up skipped for lack of consent), and writes them to `{batchId}_consent.ndjson` — one FHIR collection Bundle per patient.
- Exposes the resulting files via `Task.output` (`GET /fhir/Task/{id}` and `GET /fhir/Task`), populated only once the job is `COMPLETED`. The `/fhir/__status/{jobId}` response is untouched, so the DUP-bound transfer script sees no change.

## Test plan
- [x] `mvn -P download-ontology -B verify` equivalent unit suite for all touched areas (`ConsentFetcherTest`, `ConsentAdjusterUnitTest`, `ConsentAuditMinimizerTest`, `ResultFileManagerTest`, `ExtractDataServiceTest`, `JobPersistenceServiceTest`, `DiagnosticsStoreTest`, `JobTaskMapperTest`, `TaskControllerTest`, `FhirControllerTest`) — 219 tests, all passing
- [x] Verified `/fhir/__status/{jobId}` response is unchanged (no diff against `main` in `FhirController`/`JobManifestSchema`)

Closes #1065