### PR TITLE
Document Consent Audit Output In Task API

### DIFF
--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -114,6 +114,13 @@ If `core.ndjson` contains resources but **no patient batch files are present**, 
 
 > **No patient survived the extraction**, but core (non-patient) resources were still loaded.
 
+#### Consent Audit Files
+
+Per batch, TORCH may additionally write a `<batchId>_consent.ndjson` file holding the minimized `Consent`/`Encounter`
+resources used to compute patient consent decisions, for independent audit. These files are linked from the
+[Task API](./task-api.md#consent-audit-output), not from this endpoint's `output` array. See that page for details on
+when they're written and what they contain.
+
 ---
 
 ### Job Completion Manifest Extensions

--- a/docs/api/task-api.md
+++ b/docs/api/task-api.md
@@ -64,6 +64,43 @@ A job's status is only final (no further transitions) for `COMPLETED`, `FAILED`,
 `HIGH`-priority jobs are picked up by workers ahead of `NORMAL` ones (see [`PUT /fhir/Task/{id}`](#updating-priority)
 below to change it after creation).
 
+## Consent Audit Output
+
+Once a job reaches `COMPLETED`, `Task.output` may contain one entry per batch for which a consent audit trail was
+written to disk. Each entry has `output.type.text` set to `Consent audit NDJSON` and `output.valueUrl` pointing to
+the batch's audit file:
+
+```
+{torch.output.file.server.url}/<jobId>/<batchId>_consent.ndjson
+```
+
+```json
+{
+  "resourceType": "Task",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "completed",
+  "output": [
+    {
+      "type": { "text": "Consent audit NDJSON" },
+      "valueUrl": "http://fileserver/550e8400-e29b-41d4-a716-446655440000/3fa85f64-5717-4562-b3fc-2c963f66afa6_consent.ndjson"
+    }
+  ]
+}
+```
+
+An entry appears as soon as the corresponding `{batchId}_consent.ndjson` file exists — this includes batches
+skipped for lack of consenting patients, not just finished ones, so consent decisions stay auditable either way. It's
+absent for a batch whose audit was empty, e.g. because the CRTDL requires no consent and no `Consent`/`Encounter`
+data was ever fetched for it.
+
+Each line of the linked file is a FHIR `Bundle` (`collection`) for one patient, holding the minimized
+`Consent`/`Encounter` resources used to calculate that patient's consent time window:
+
+| Resource    | Fields kept                                                        |
+|-------------|---------------------------------------------------------------------|
+| `Consent`   | `id`, `meta.profile`, `patient`, `provision`, `dateTime`, `status` |
+| `Encounter` | `id`, `meta.profile`, `subject`, `period`                          |
+
 ---
 
 ## Searching Tasks


### PR DESCRIPTION
## Summary
- Document the `Task.output` consent audit entries added by #1161 (closing #1065): when they appear (job `COMPLETED`, one per batch with an audit file), the URL shape, and that skipped batches get one too.
- Document the `<batchId>_consent.ndjson` file contents: one `Bundle` per patient, minimized `Consent`/`Encounter` fields.
- Add a short pointer to that section from `api.md`'s Result Files list, which enumerated output files but omitted the consent audit file.

Docs only, no code change.

## Test plan
- [x] Docs-only change; no test suite applies.
- [ ] Reviewer: sanity-check the rendered VitePress pages (task-api.md `#consent-audit-output` anchor, api.md pointer link).

Closes #1164