### PR TITLE
Add Positive Outcome To Diagnostics

### DIFF
--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -203,6 +203,9 @@ Example completed manifest:
             "Resource-Outside-Batch": 0,
             "Cascading-Delete": 0
           }
+        },
+        "Resource-Inclusions": {
+          "med-adm-group": 12
         }
       }
     },

--- a/src/main/java/de/medizininformatikinitiative/torch/diagnostics/BatchDetails.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/diagnostics/BatchDetails.java
@@ -6,21 +6,23 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * Records different measurements during the processing of a single batch.
  *
- * @param nanosElapsed      the amount of nanoseconds elapsed at each stage
- * @param numCohortPatients the amount of patients in the original cohort of this batch before extraction (i.e. before any exclusions)
- * @param numFinalPatients  the amount of patients in this batch after extraction (i.e. after exclusions could have occurred)
+ * @param nanosElapsed        the amount of nanoseconds elapsed at each stage
+ * @param numCohortPatients   the amount of patients in the original cohort of this batch before extraction (i.e. before any exclusions)
+ * @param numFinalPatients    the amount of patients in this batch after extraction (i.e. after exclusions could have occurred)
+ * @param resourceInclusions  the amount of resources that successfully completed extraction, per AttributeGroup-ID
  */
-public record BatchDetails(Map<PipelineStage, Long> nanosElapsed, int numCohortPatients, int numFinalPatients) {
+public record BatchDetails(Map<PipelineStage, Long> nanosElapsed, int numCohortPatients, int numFinalPatients,
+                           Map<String, Integer> resourceInclusions) {
 
     public static BatchDetails empty() {
-        return new BatchDetails(new ConcurrentHashMap<>(), 0, 0);
+        return new BatchDetails(new ConcurrentHashMap<>(), 0, 0, new ConcurrentHashMap<>());
     }
 
     public BatchDetails setNumCohortPatients(int numCohortPatients) {
-        return new BatchDetails(nanosElapsed, numCohortPatients, numFinalPatients);
+        return new BatchDetails(nanosElapsed, numCohortPatients, numFinalPatients, resourceInclusions);
     }
 
     public BatchDetails setFinalPatientCount(int numFinalPatients) {
-        return new BatchDetails(nanosElapsed, numCohortPatients, numFinalPatients);
+        return new BatchDetails(nanosElapsed, numCohortPatients, numFinalPatients, resourceInclusions);
     }
 }

--- a/src/main/java/de/medizininformatikinitiative/torch/diagnostics/JobDiagnosticSummary.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/diagnostics/JobDiagnosticSummary.java
@@ -25,18 +25,20 @@ import java.util.stream.Collectors;
  *                              measurement and is therefore reported separately via {@code cohortQueryDurationMs}
  * @param patientSummaries      sum amount of patient exclusion events across all batches
  * @param resourceSummaries     resource exclusion events grouped by AttributeGroup-ID
+ * @param resourceInclusions    resources that successfully completed extraction, grouped by AttributeGroup-ID
  */
 public record JobDiagnosticSummary(@JsonProperty("Num-Cohort-Patients") int numCohortPatients,
                                    @JsonProperty("Num-Final-Patients") int numFinalPatients,
                                    @JsonProperty("Cohort-Query-Duration-Ms") Long cohortQueryDurationMs,
                                    @JsonProperty("Duration-Measurements") Map<PipelineStage, DurationSummary> durationSummaries,
                                    @JsonProperty("Patient-Exclusions") Map<PatientExclusionStage, Integer> patientSummaries,
-                                   @JsonProperty("Resource-Exclusions")Map<String, GroupSummary> resourceSummaries
+                                   @JsonProperty("Resource-Exclusions")Map<String, GroupSummary> resourceSummaries,
+                                   @JsonProperty("Resource-Inclusions") Map<String, Integer> resourceInclusions
 ) {
 
     public static JobDiagnosticSummary empty() {
         return new JobDiagnosticSummary(0, 0, null, new HashMap<>(),
-                new HashMap<>(), new HashMap<>()
+                new HashMap<>(), new HashMap<>(), new HashMap<>()
         );
     }
 
@@ -51,10 +53,11 @@ public record JobDiagnosticSummary(@JsonProperty("Num-Cohort-Patients") int numC
         var durations = computeTimingSummary(batchDiagnostics);
         var resourcesExclusions = computeResourceSummaries(batchDiagnostics);
         var patientExclusions =  computePatientSummaries(batchDiagnostics);
+        var resourceInclusions = computeResourceInclusionSummary(batchDiagnostics);
         var cohortPatients = sumCohortPatients(batchDiagnostics);
         var finalPatients = sumFinalPatients(batchDiagnostics);
 
-        return new JobDiagnosticSummary(cohortPatients, finalPatients, cohortQueryDurationMs, durations, patientExclusions, resourcesExclusions);
+        return new JobDiagnosticSummary(cohortPatients, finalPatients, cohortQueryDurationMs, durations, patientExclusions, resourcesExclusions, resourceInclusions);
     }
 
     /**
@@ -169,6 +172,20 @@ public record JobDiagnosticSummary(@JsonProperty("Num-Cohort-Patients") int numC
         }));
 
         return exclusionsPerGroup;
+    }
+
+    /**
+     * Computes the sum of successfully extracted resources per AttributeGroup across all batch diagnostics.
+     *
+     * @param diagnostics   the batch diagnostics of each batch of the job
+     * @return              the accumulated resource inclusions per AttributeGroup-ID
+     */
+    private static Map<String, Integer> computeResourceInclusionSummary(List<BatchDiagnostics> diagnostics) {
+        Map<String, Integer> resourceInclusions = new HashMap<>();
+        diagnostics.forEach(d -> d.batchDetails().resourceInclusions()
+                .forEach((groupId, count) -> resourceInclusions.merge(groupId, count, Integer::sum)));
+
+        return resourceInclusions;
     }
 
     /**

--- a/src/main/java/de/medizininformatikinitiative/torch/model/extraction/ExtractionPatientBatch.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/model/extraction/ExtractionPatientBatch.java
@@ -6,8 +6,10 @@ import org.hl7.fhir.r4.model.Bundle;
 
 import java.io.IOException;
 import java.io.Writer;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 public record ExtractionPatientBatch(Map<String, ExtractionResourceBundle> bundles,
@@ -34,6 +36,30 @@ public record ExtractionPatientBatch(Map<String, ExtractionResourceBundle> bundl
 
     public int getNumPatients() {
         return bundles.size();
+    }
+
+    /**
+     * Counts resources that successfully completed extraction across all patient bundles, grouped by AttributeGroup-ID.
+     *
+     * @return groupId to count of successfully extracted resources, summed over all patients in this batch
+     */
+    public Map<String, Integer> resourceInclusionCounts() {
+        return resourceInclusionCounts(id -> true);
+    }
+
+    /**
+     * Counts resources that successfully completed extraction and are accepted by {@code includeFilter}, across all
+     * patient bundles, grouped by AttributeGroup-ID.
+     *
+     * @param includeFilter predicate deciding which resources are counted (e.g. to avoid double-counting resources
+     *                      that are handed off to a later processing stage for a final count there)
+     * @return groupId to count of successfully extracted resources, summed over all patients in this batch
+     */
+    public Map<String, Integer> resourceInclusionCounts(Predicate<ExtractionId> includeFilter) {
+        Map<String, Integer> counts = new HashMap<>();
+        bundles.values().forEach(bundle -> bundle.resourceInclusionCounts(includeFilter)
+                .forEach((groupId, count) -> counts.merge(groupId, count, Integer::sum)));
+        return counts;
     }
 
     public void writeToFhirBundles(FhirContext fhirContext, Writer out, String extractionId) throws IOException {

--- a/src/main/java/de/medizininformatikinitiative/torch/model/extraction/ExtractionResourceBundle.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/model/extraction/ExtractionResourceBundle.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static org.hl7.fhir.r4.model.Bundle.BundleType.TRANSACTION;
@@ -115,6 +116,35 @@ public record ExtractionResourceBundle(ConcurrentHashMap<ExtractionId, ResourceE
 
         return new ExtractionResourceBundle(new ConcurrentHashMap<>(mergedInfo),   // deep immutable
                 newCache);
+    }
+
+    /**
+     * Counts resources that successfully completed extraction (i.e. have a resolved cache entry), grouped by
+     * AttributeGroup-ID. A resource valid for multiple groups is counted once per group.
+     *
+     * @return groupId to count of successfully extracted resources
+     */
+    public Map<String, Integer> resourceInclusionCounts() {
+        return resourceInclusionCounts(id -> true);
+    }
+
+    /**
+     * Counts resources that successfully completed extraction (i.e. have a resolved cache entry) and are accepted by
+     * {@code includeFilter}, grouped by AttributeGroup-ID. A resource valid for multiple groups is counted once per
+     * group.
+     *
+     * @param includeFilter predicate deciding which resources are counted (e.g. to avoid double-counting resources
+     *                      that are handed off to a later processing stage for a final count there)
+     * @return groupId to count of successfully extracted resources
+     */
+    public Map<String, Integer> resourceInclusionCounts(Predicate<ExtractionId> includeFilter) {
+        Map<String, Integer> counts = new HashMap<>();
+        extractionInfoMap.forEach((id, info) -> {
+            if (includeFilter.test(id) && cache.getOrDefault(id, Optional.empty()).isPresent()) {
+                info.groups().forEach(groupId -> counts.merge(groupId, 1, Integer::sum));
+            }
+        });
+        return counts;
     }
 
     /**

--- a/src/main/java/de/medizininformatikinitiative/torch/service/ExtractDataService.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/service/ExtractDataService.java
@@ -17,6 +17,7 @@ import de.medizininformatikinitiative.torch.jobhandling.result.BatchResult;
 import de.medizininformatikinitiative.torch.jobhandling.result.BatchSelection;
 import de.medizininformatikinitiative.torch.jobhandling.result.CoreResult;
 import de.medizininformatikinitiative.torch.jobhandling.workunit.WorkUnitStatus;
+import de.medizininformatikinitiative.torch.management.CompartmentManager;
 import de.medizininformatikinitiative.torch.management.ProcessedGroupFactory;
 import de.medizininformatikinitiative.torch.model.consent.PatientBatchWithConsent;
 import de.medizininformatikinitiative.torch.model.crtdl.annotated.AnnotatedAttributeGroup;
@@ -52,7 +53,8 @@ import static java.util.Objects.requireNonNull;
  * <p>Provides batch processing via {@link #processBatch(BatchSelection)} and core processing
  * via {@link #processCore(Job, ExtractionResourceBundle)}.
  *
- * <p>Diagnostics are collected through {@link BatchExclusions} on the happy path.
+ * <p>Diagnostics are collected through {@link BatchExclusions} and the resource-inclusion counts
+ * in {@link de.medizininformatikinitiative.torch.diagnostics.BatchDetails} on the happy path.
  * Unexpected failures are not swallowed and bubble up as {@link Mono#error} so callers can
  * route them through the job failure handling logic.
  *
@@ -77,6 +79,7 @@ public class ExtractDataService {
     private final DataStore dataStore;
     private final PostCascadeMustHaveChecker postCascadeMustHaveChecker;
     private final TorchProperties torchProperties;
+    private final CompartmentManager compartmentManager;
 
     public ExtractDataService(ResultFileManager resultFileManager,
                               ProcessedGroupFactory processedGroupFactory,
@@ -88,7 +91,8 @@ public class ExtractDataService {
                               ConsentHandler consentHandler,
                               DataStore dataStore,
                               PostCascadeMustHaveChecker postCascadeMustHaveChecker,
-                              TorchProperties torchProperties) {
+                              TorchProperties torchProperties,
+                              CompartmentManager compartmentManager) {
         this.resultFileManager = requireNonNull(resultFileManager);
         this.processedGroupFactory = requireNonNull(processedGroupFactory);
         this.directResourceLoader = requireNonNull(directResourceLoader);
@@ -100,6 +104,7 @@ public class ExtractDataService {
         this.dataStore = requireNonNull(dataStore);
         this.postCascadeMustHaveChecker = requireNonNull(postCascadeMustHaveChecker);
         this.torchProperties = requireNonNull(torchProperties);
+        this.compartmentManager = requireNonNull(compartmentManager);
     }
 
     private static void logMemory(UUID id) {
@@ -192,6 +197,10 @@ public class ExtractDataService {
         diagnostics.batchDetails().nanosElapsed().put(stage, elapsed);
     }
 
+    private static void recordResourceInclusions(BatchDiagnostics diagnostics, Map<String, Integer> counts) {
+        counts.forEach((groupId, count) -> diagnostics.batchDetails().resourceInclusions().merge(groupId, count, Integer::sum));
+    }
+
     /**
      * Continues batch processing once consent has been resolved.
      *
@@ -226,9 +235,15 @@ public class ExtractDataService {
                         filterPostCascadeMustHaveViolations(patientBatch, groupsToProcess.directPatientCompartmentGroups()))
                 .doOnNext(loadedBatch ->
                         logger.debug("Batch resolved references {} with {} patients",batchId, loadedBatch.patientIds().size()))
-                .map(patientBatch ->
-                        executeAndMeasure(PipelineStage.COPY_REDACT, patientBatch.diagnostics(), () ->
-                                batchCopierRedacter.transformBatch(ExtractionPatientBatch.of(patientBatch), groupsToProcess.allGroups())))
+                .map(patientBatch -> {
+                    ExtractionPatientBatch transformed = executeAndMeasure(PipelineStage.COPY_REDACT, patientBatch.diagnostics(), () ->
+                            batchCopierRedacter.transformBatch(ExtractionPatientBatch.of(patientBatch), groupsToProcess.allGroups()));
+                    // Non-compartment resources are handed off to processCore() via toCoreBundle() and counted there instead,
+                    // to avoid counting them twice.
+                    recordResourceInclusions(patientBatch.diagnostics(),
+                            transformed.resourceInclusionCounts(compartmentManager::isInCompartment));
+                    return transformed;
+                })
                 .doOnNext(__ -> logger.debug("Batch finished extraction {}", batchId))
                 .flatMap(extractedBatch ->
                         writeBatch(jobId.toString(), extractedBatch)
@@ -302,6 +317,7 @@ public class ExtractDataService {
                 .flatMap(cb -> {
                     ExtractionResourceBundle transformed = executeAndMeasure(PipelineStage.COPY_REDACT, diagnostics, () ->
                                     batchCopierRedacter.transformBundle(cb, groupsToProcess.allGroups()));
+                    recordResourceInclusions(diagnostics, transformed.resourceInclusionCounts());
 
                     if (transformed.isEmpty()) {
                         return Mono.just(new CoreResult(job.id(), List.of(), WorkUnitStatus.SKIPPED,

--- a/src/test/java/de/medizininformatikinitiative/torch/DiagnosticsBlackBoxIT.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/DiagnosticsBlackBoxIT.java
@@ -265,7 +265,7 @@ public class DiagnosticsBlackBoxIT {
         var jobSummary = optionalSummary.get();
         assertThat(jobSummary.numCohortPatients()).isEqualTo(1);
         assertThat(jobSummary.numFinalPatients()).isEqualTo(0);
-        assertThat(jobSummary.durationSummaries().keySet()).containsExactlyInAnyOrder(PipelineStage.values());
+        assertThat(jobSummary.durationSummaries().keySet()).containsExactlyInAnyOrder(PER_BATCH_STAGES);
         assertThat(jobSummary.durationSummaries().values()).allSatisfy(duration -> {
             assertThat(duration.averageMs()).isGreaterThanOrEqualTo(0);
             assertThat(duration.medianMs()).isGreaterThanOrEqualTo(0);

--- a/src/test/java/de/medizininformatikinitiative/torch/diagnostics/DiagnosticsStoreTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/diagnostics/DiagnosticsStoreTest.java
@@ -58,7 +58,7 @@ class DiagnosticsStoreTest {
                 DIRECT_LOAD, 7678L,
                 REFERENCE_RESOLVE, 1500L,
                 CASCADING_DELETE, 3439L,
-                COPY_REDACT, 1096L), 5426, 7316);
+                COPY_REDACT, 1096L), 5426, 7316, Map.of(GROUP_1, 12));
         var batchExclusions_1 = BatchExclusions.empty();
         batchExclusions_1.addMustHaveExclusionCore(GROUP_1, RESOURCE_1, ATTRIBUTE_1);
         batchExclusions_1.addReferenceNotFoundExclusionCore(GROUP_1, RESOURCE_1);
@@ -71,7 +71,7 @@ class DiagnosticsStoreTest {
                 DIRECT_LOAD, 4887L,
                 REFERENCE_RESOLVE, 3503L,
                 CASCADING_DELETE, 6772L,
-                COPY_REDACT, 4847L), 8860, 9659);
+                COPY_REDACT, 4847L), 8860, 9659, Map.of(GROUP_2, 34));
         var batchExclusions_2 = BatchExclusions.empty();
         batchExclusions_2.addMustHaveExclusionCore(GROUP_2, RESOURCE_2, ATTRIBUTE_2);
         batchExclusions_2.addReferenceNotFoundExclusionCore(GROUP_2, RESOURCE_2);

--- a/src/test/java/de/medizininformatikinitiative/torch/diagnostics/JobDiagnosticsSummaryTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/diagnostics/JobDiagnosticsSummaryTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import static de.medizininformatikinitiative.torch.TestUtils.toMillis;
 import static de.medizininformatikinitiative.torch.diagnostics.PipelineStage.CASCADING_DELETE;
@@ -204,6 +205,30 @@ public class JobDiagnosticsSummaryTest {
                 diagnostics.batchExclusions().addCascadingDeleteExclusion(groupId, resourceId, patientId);
                 diagnostics.batchExclusions().addCascadingDeleteExclusionCore(groupId, resourceId);
             }
+        }
+
+        @Test
+        void testResourceInclusions_sameGroupAcrossBatches() {
+            var batch1 = BatchDiagnostics.empty();
+            var batch2 = BatchDiagnostics.empty();
+            batch1.batchDetails().resourceInclusions().merge(GROUP_1, NUM_1, Integer::sum);
+            batch2.batchDetails().resourceInclusions().merge(GROUP_1, NUM_2, Integer::sum);
+
+            var summary = JobDiagnosticSummary.initFromBatches(List.of(batch1, batch2));
+
+            assertThat(summary.resourceInclusions()).containsExactlyInAnyOrderEntriesOf(Map.of(GROUP_1, NUM_1 + NUM_2));
+        }
+
+        @Test
+        void testResourceInclusions_differentGroups() {
+            var batch1 = BatchDiagnostics.empty();
+            var batch2 = BatchDiagnostics.empty();
+            batch1.batchDetails().resourceInclusions().merge(GROUP_1, NUM_1, Integer::sum);
+            batch2.batchDetails().resourceInclusions().merge(GROUP_2, NUM_2, Integer::sum);
+
+            var summary = JobDiagnosticSummary.initFromBatches(List.of(batch1, batch2));
+
+            assertThat(summary.resourceInclusions()).containsExactlyInAnyOrderEntriesOf(Map.of(GROUP_1, NUM_1, GROUP_2, NUM_2));
         }
     }
 

--- a/src/test/java/de/medizininformatikinitiative/torch/model/extraction/ExtractionPatientBatchTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/model/extraction/ExtractionPatientBatchTest.java
@@ -83,4 +83,26 @@ class ExtractionPatientBatchTest {
 
         assertThat(batch.totalResources()).isEqualTo(2L);
     }
+
+    @Test
+    void resourceInclusionCounts_sumsAcrossPatientBundles() {
+        var id1 = ExtractionId.fromRelativeUrl("Patient/1");
+        var infoMap1 = new ConcurrentHashMap<ExtractionId, ResourceExtractionInfo>();
+        infoMap1.put(id1, new ResourceExtractionInfo(Set.of("G1"), Map.of()));
+        var cache1 = new ConcurrentHashMap<ExtractionId, Optional<Resource>>();
+        cache1.put(id1, Optional.of(new Patient()));
+
+        var id2 = ExtractionId.fromRelativeUrl("Patient/2");
+        var infoMap2 = new ConcurrentHashMap<ExtractionId, ResourceExtractionInfo>();
+        infoMap2.put(id2, new ResourceExtractionInfo(Set.of("G1", "G2"), Map.of()));
+        var cache2 = new ConcurrentHashMap<ExtractionId, Optional<Resource>>();
+        cache2.put(id2, Optional.of(new Patient()));
+
+        var batch = new ExtractionPatientBatch(Map.of(
+                "p1", new ExtractionResourceBundle(infoMap1, cache1),
+                "p2", new ExtractionResourceBundle(infoMap2, cache2)
+        ), UUID.randomUUID());
+
+        assertThat(batch.resourceInclusionCounts()).containsExactlyInAnyOrderEntriesOf(Map.of("G1", 2, "G2", 1));
+    }
 }

--- a/src/test/java/de/medizininformatikinitiative/torch/model/extraction/ExtractionResourceBundleTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/model/extraction/ExtractionResourceBundleTest.java
@@ -125,6 +125,59 @@ class ExtractionResourceBundleTest {
     }
 
     @Test
+    void resourceInclusionCounts_countsOncePerGroupPerResource() {
+        ConcurrentHashMap<ExtractionId, ResourceExtractionInfo> infoMap = new ConcurrentHashMap<>(
+                Map.of(
+                        ExtractionId.fromRelativeUrl("Patient/R1"), new ResourceExtractionInfo(Set.of("G1", "G2"), Map.of()),
+                        ExtractionId.fromRelativeUrl("Patient/R2"), new ResourceExtractionInfo(Set.of("G1"), Map.of())
+                )
+        );
+
+        ExtractionResourceBundle bundle = new ExtractionResourceBundle(infoMap, CacheBuilder.create()
+                .with("Patient/R1", new Patient().setId("Patient/R1"))
+                .with("Patient/R2", new Patient().setId("Patient/R2"))
+                .build());
+
+        assertThat(bundle.resourceInclusionCounts()).containsExactlyInAnyOrderEntriesOf(Map.of("G1", 2, "G2", 1));
+    }
+
+    @Test
+    void resourceInclusionCounts_excludesMissingOrEmptyCacheEntries() {
+        ConcurrentHashMap<ExtractionId, ResourceExtractionInfo> infoMap = new ConcurrentHashMap<>(
+                Map.of(
+                        ExtractionId.fromRelativeUrl("Patient/R1"), new ResourceExtractionInfo(Set.of("G1"), Map.of()),
+                        ExtractionId.fromRelativeUrl("Patient/R2"), new ResourceExtractionInfo(Set.of("G1"), Map.of())
+                )
+        );
+
+        ExtractionResourceBundle bundle = new ExtractionResourceBundle(infoMap, CacheBuilder.create()
+                .with("Patient/R1", new Patient().setId("Patient/R1"))
+                .empty("Patient/R2")
+                .build());
+
+        assertThat(bundle.resourceInclusionCounts()).containsExactlyInAnyOrderEntriesOf(Map.of("G1", 1));
+    }
+
+    @Test
+    void resourceInclusionCounts_appliesIncludeFilter() {
+        ConcurrentHashMap<ExtractionId, ResourceExtractionInfo> infoMap = new ConcurrentHashMap<>(
+                Map.of(
+                        ExtractionId.fromRelativeUrl("Patient/R1"), new ResourceExtractionInfo(Set.of("G1"), Map.of()),
+                        ExtractionId.fromRelativeUrl("Organization/R2"), new ResourceExtractionInfo(Set.of("G1"), Map.of())
+                )
+        );
+
+        ExtractionResourceBundle bundle = new ExtractionResourceBundle(infoMap, CacheBuilder.create()
+                .with("Patient/R1", new Patient().setId("Patient/R1"))
+                .with("Organization/R2", new Patient().setId("Organization/R2"))
+                .build());
+
+        var counts = bundle.resourceInclusionCounts(id -> id.resourceType().equals("Patient"));
+
+        assertThat(counts).containsExactlyInAnyOrderEntriesOf(Map.of("G1", 1));
+    }
+
+    @Test
     void putDoesNotThrowOnIllegalExtractionId() {
         ExtractionResourceBundle bundle = new ExtractionResourceBundle(
                 new ConcurrentHashMap<>(),

--- a/src/test/java/de/medizininformatikinitiative/torch/service/ExtractDataServiceTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/service/ExtractDataServiceTest.java
@@ -18,6 +18,7 @@ import de.medizininformatikinitiative.torch.jobhandling.failure.Severity;
 import de.medizininformatikinitiative.torch.jobhandling.result.BatchSelection;
 import de.medizininformatikinitiative.torch.jobhandling.workunit.WorkUnitState;
 import de.medizininformatikinitiative.torch.jobhandling.workunit.WorkUnitStatus;
+import de.medizininformatikinitiative.torch.management.CompartmentManager;
 import de.medizininformatikinitiative.torch.management.ProcessedGroupFactory;
 import de.medizininformatikinitiative.torch.model.consent.PatientBatchWithConsent;
 import de.medizininformatikinitiative.torch.model.crtdl.annotated.AnnotatedCrtdl;
@@ -93,6 +94,8 @@ class ExtractDataServiceTest {
     PostCascadeMustHaveChecker postCascadeMustHaveChecker;
     @Mock
     TorchProperties torchProperties;
+    @Mock
+    CompartmentManager compartmentManager;
 
     ExtractDataService service;
     ExtractDataService spyService;
@@ -129,7 +132,8 @@ class ExtractDataServiceTest {
                 consentHandler,
                 dataStore,
                 postCascadeMustHaveChecker,
-                torchProperties
+                torchProperties,
+                compartmentManager
         );
         spyService = Mockito.spy(service);
     }
@@ -183,6 +187,7 @@ class ExtractDataServiceTest {
                         .thenReturn(ofResult);
 
                 ExtractionPatientBatch extracted = mock(ExtractionPatientBatch.class);
+                when(extracted.resourceInclusionCounts(any())).thenReturn(Map.of());
                 when(batchCopierRedacter.transformBatch(eq(ofResult), anyMap()))
                         .thenReturn(extracted);
 
@@ -206,6 +211,68 @@ class ExtractDataServiceTest {
 
                 verifyNoInteractions(consentHandler); // consentCodes empty branch
                 verify(spyService).writeBatch(jobId.toString(), extracted);
+            }
+        }
+
+        @Test
+        void processBatch_recordsResourceInclusionCounts() {
+            UUID jobId = UUID.randomUUID();
+            UUID batchId = UUID.randomUUID();
+
+            Job job = job(jobId, JobStatus.PENDING, WorkUnitState.initNow(), Map.of(), WorkUnitState.initNow());
+
+            GroupsToProcess groups = mock(GroupsToProcess.class);
+            when(processedGroupFactory.create(any())).thenReturn(groups);
+            when(groups.directPatientCompartmentGroups()).thenReturn(List.of());
+            when(groups.allGroups()).thenReturn(Map.of());
+
+            PatientBatch rawBatch = mock(PatientBatch.class);
+            when(rawBatch.batchId()).thenReturn(batchId);
+            when(rawBatch.ids()).thenReturn(List.of());
+            when(rawBatch.diagnostics()).thenReturn(BatchDiagnostics.empty());
+
+            BatchState batchState = mock(BatchState.class);
+            BatchState finishedState = mock(BatchState.class);
+            when(batchState.finishNow(WorkUnitStatus.FINISHED)).thenReturn(finishedState);
+
+            BatchSelection selection = mock(BatchSelection.class);
+            when(selection.job()).thenReturn(job);
+            when(selection.batchState()).thenReturn(batchState);
+            when(selection.batch()).thenReturn(rawBatch);
+
+            BatchDiagnostics diagnostics = BatchDiagnostics.empty();
+            PatientBatchWithConsent bwc = mock(PatientBatchWithConsent.class);
+            when(bwc.keep(any())).thenReturn(bwc);
+            when(bwc.diagnostics()).thenReturn(diagnostics);
+
+            when(directResourceLoader.directLoadPatientCompartment(anyList(), any()))
+                    .thenReturn(Mono.just(bwc));
+            when(referenceResolver.resolvePatientBatch(eq(bwc), anyMap()))
+                    .thenReturn(Mono.just(bwc));
+            when(cascadingDelete.handlePatientBatch(eq(bwc), anyMap()))
+                    .thenReturn(bwc);
+
+            ExtractionPatientBatch ofResult = mock(ExtractionPatientBatch.class);
+            try (MockedStatic<ExtractionPatientBatch> mocked = mockStatic(ExtractionPatientBatch.class)) {
+                mocked.when(() -> ExtractionPatientBatch.of(any()))
+                        .thenReturn(ofResult);
+
+                ExtractionPatientBatch extracted = mock(ExtractionPatientBatch.class);
+                when(extracted.resourceInclusionCounts(any())).thenReturn(Map.of("G1", 3, "G2", 1));
+                when(batchCopierRedacter.transformBatch(eq(ofResult), anyMap()))
+                        .thenReturn(extracted);
+
+                ExtractionResourceBundle coreBundle = mock(ExtractionResourceBundle.class);
+                when(batchToCoreWriter.toCoreBundle(extracted)).thenReturn(coreBundle);
+
+                doReturn(Mono.empty()).when(spyService).writeBatch(eq(jobId.toString()), eq(extracted));
+
+                StepVerifier.create(spyService.processBatch(selection))
+                        .assertNext(res -> assertThat(res.batchState()).isSameAs(finishedState))
+                        .verifyComplete();
+
+                assertThat(diagnostics.batchDetails().resourceInclusions())
+                        .containsExactlyInAnyOrderEntriesOf(Map.of("G1", 3, "G2", 1));
             }
         }
 
@@ -265,6 +332,7 @@ class ExtractDataServiceTest {
                         .thenReturn(ofResult);
 
                 ExtractionPatientBatch extracted = mock(ExtractionPatientBatch.class);
+                when(extracted.resourceInclusionCounts(any())).thenReturn(Map.of());
                 when(batchCopierRedacter.transformBatch(eq(ofResult), anyMap()))
                         .thenReturn(extracted);
 
@@ -338,6 +406,7 @@ class ExtractDataServiceTest {
                         .thenReturn(ofResult);
 
                 ExtractionPatientBatch extracted = mock(ExtractionPatientBatch.class);
+                when(extracted.resourceInclusionCounts(any())).thenReturn(Map.of());
                 when(batchCopierRedacter.transformBatch(eq(ofResult), anyMap()))
                         .thenReturn(extracted);
 
@@ -446,6 +515,7 @@ class ExtractDataServiceTest {
 
                 ExtractionPatientBatch extracted = mock(ExtractionPatientBatch.class);
                 when(extracted.isEmpty()).thenReturn(true);
+                when(extracted.resourceInclusionCounts(any())).thenReturn(Map.of());
                 when(batchCopierRedacter.transformBatch(eq(ofResult), anyMap())).thenReturn(extracted);
 
                 ExtractionResourceBundle coreBundle = mock(ExtractionResourceBundle.class);
@@ -573,6 +643,7 @@ class ExtractDataServiceTest {
             ExtractionResourceBundle transformed = mock(ExtractionResourceBundle.class);
             when(transformed.isEmpty()).thenReturn(true);
 
+            when(transformed.resourceInclusionCounts()).thenReturn(Map.of());
             when(batchCopierRedacter.transformBundle(any(ExtractionResourceBundle.class), anyMap()))
                     .thenReturn(transformed);
 
@@ -610,6 +681,7 @@ class ExtractDataServiceTest {
             ExtractionResourceBundle transformed = mock(ExtractionResourceBundle.class);
             when(transformed.isEmpty()).thenReturn(false);
 
+            when(transformed.resourceInclusionCounts()).thenReturn(Map.of());
             when(batchCopierRedacter.transformBundle(any(ExtractionResourceBundle.class), anyMap()))
                     .thenReturn(transformed);
 
@@ -623,6 +695,41 @@ class ExtractDataServiceTest {
                     .verifyComplete();
 
             verify(spyService).writeBundle(jobId.toString(), transformed);
+        }
+
+        @Test
+        void processCore_recordsResourceInclusionCounts() {
+            UUID jobId = UUID.randomUUID();
+
+            Job job = job(jobId, JobStatus.PENDING, WorkUnitState.initNow(), Map.of(), WorkUnitState.initNow());
+            AnnotatedCrtdl crtdl = job.parameters().crtdl();
+
+            GroupsToProcess groups = mock(GroupsToProcess.class);
+            when(processedGroupFactory.create(crtdl)).thenReturn(groups);
+            when(groups.directNoPatientGroups()).thenReturn(List.of());
+            when(groups.allGroups()).thenReturn(Map.of());
+
+            ResourceBundle rb = new ResourceBundle();
+            when(directResourceLoader.processCoreAttributeGroups(anyList(), any(ResourceBundle.class), any()))
+                    .thenReturn(Mono.just(rb));
+            when(referenceResolver.resolveCoreBundle(eq(rb), anyMap(), any()))
+                    .thenReturn(Mono.just(rb));
+
+            when(dataStore.groupReferencesByTypeInChunks(any())).thenReturn(List.of());
+
+            ExtractionResourceBundle transformed = mock(ExtractionResourceBundle.class);
+            when(transformed.isEmpty()).thenReturn(false);
+            when(transformed.resourceInclusionCounts()).thenReturn(Map.of("G1", 2));
+
+            when(batchCopierRedacter.transformBundle(any(ExtractionResourceBundle.class), anyMap()))
+                    .thenReturn(transformed);
+
+            doReturn(Mono.empty()).when(spyService).writeBundle(eq(jobId.toString()), eq(transformed));
+
+            StepVerifier.create(spyService.processCore(job, new ExtractionResourceBundle()))
+                    .assertNext(res -> assertThat(res.diagnostics().orElseThrow().batchDetails().resourceInclusions())
+                            .containsExactlyInAnyOrderEntriesOf(Map.of("G1", 2)))
+                    .verifyComplete();
         }
 
         @Test

--- a/src/test/java/de/medizininformatikinitiative/torch/service/JobPersistenceServiceTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/service/JobPersistenceServiceTest.java
@@ -1148,7 +1148,7 @@ class JobPersistenceServiceTest {
                     DIRECT_LOAD, 7678L,
                     REFERENCE_RESOLVE, 1500L,
                     CASCADING_DELETE, 3439L,
-                    COPY_REDACT, 1096L), 5426, 7316);
+                    COPY_REDACT, 1096L), 5426, 7316, Map.of());
             var batchExclusions_1 = BatchExclusions.empty();
             batchExclusions_1.addMustHaveExclusionCore(GROUP_1, RESOURCE_1, ATTRIBUTE_1);
             batchExclusions_1.addReferenceNotFoundExclusionCore(GROUP_1, RESOURCE_1);
@@ -1161,7 +1161,7 @@ class JobPersistenceServiceTest {
                     DIRECT_LOAD, 4887L,
                     REFERENCE_RESOLVE, 3503L,
                     CASCADING_DELETE, 6772L,
-                    COPY_REDACT, 4847L), 8860, 9659);
+                    COPY_REDACT, 4847L), 8860, 9659, Map.of());
             var batchExclusions_2 = BatchExclusions.empty();
             batchExclusions_2.addMustHaveExclusionCore(GROUP_2, RESOURCE_2, ATTRIBUTE_2);
             batchExclusions_2.addReferenceNotFoundExclusionCore(GROUP_2, RESOURCE_2);
@@ -1183,7 +1183,7 @@ class JobPersistenceServiceTest {
                     new AnnotatedDataExtraction(List.of()),
                     Optional.empty()), List.of(), "");
 
-            var details = new BatchDetails(Map.of(), 2, 1);
+            var details = new BatchDetails(Map.of(), 2, 1, Map.of());
             var batchExclusions = BatchExclusions.empty();
             batchExclusions.addPatientExclusion(PatientExclusionStage.DIRECT_LOAD, PATIENT_1);
             var diagnostics = new BatchDiagnostics(batchExclusions, details, ConsentAudit.empty());
@@ -1204,7 +1204,7 @@ class JobPersistenceServiceTest {
                     new AnnotatedDataExtraction(List.of()),
                     Optional.empty()), List.of(), "");
 
-            var details = new BatchDetails(Map.of(), 2, 1);
+            var details = new BatchDetails(Map.of(), 2, 1, Map.of());
             var diagnostics = new BatchDiagnostics(BatchExclusions.empty(), details, ConsentAudit.empty());
 
             persistenceService.selectNextInternal(jobId);


### PR DESCRIPTION
## Summary
- Adds per-AttributeGroup counts of resources that successfully completed extraction (`Resource-Inclusions` in `job-summary.json`), alongside the existing exclusion counts.
- Batch-level counting is filtered to compartment resources only, since non-compartment resources are handed off to `processCore()` via `toCoreBundle()` and get a second COPY_REDACT pass there — counting them at both stages would double-count.
- Incidental fix: `DiagnosticsBlackBoxIT.testCascadingDeleteOrphanedResource` (added by a since-merged `main` commit, unrelated to this PR) asserted `durationSummaries().keySet()` against the raw `PipelineStage.values()`, which now includes `COHORT_QUERY` — a stage that's deliberately excluded from `durationSummaries` (reported separately via `cohortQueryDurationMs`) elsewhere in that same file's other three tests. Aligned it with the `PER_BATCH_STAGES` constant the other three tests already use correctly.

## Test plan
- [x] `mvn -o test` on the diagnostics, extraction, `ExtractDataServiceTest`, and `JobPersistenceServiceTest` packages — 0 failures/errors
- [x] `mvn -o compile test-compile` clean
- [x] `blackbox-integration-tests` CI failure diagnosed and fixed (isolated to the one unrelated assertion above)

Closes #1037