### PR TITLE
Fix Core Batch Write Failures Being Silently Swallowed in JobPersistenceService

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/torch/service/JobPersistenceService.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/service/JobPersistenceService.java
@@ -427,13 +427,9 @@ public class JobPersistenceService {
         UUID jobId = result.jobId();
 
         updateJobAndReturn(jobId, job -> {
-            result.resultCoreBundle().ifPresent(bundle -> {
-                try {
-                    saveCoreBatch(jobId, result.batchState().batchId(), bundle);
-                } catch (IOException e) {
-                    logger.warn("Failed to save core batch for job {}: {}", jobId, e.getMessage(), e);
-                }
-            });
+            if (result.resultCoreBundle().isPresent()) {
+                saveCoreBatch(jobId, result.batchState().batchId(), result.resultCoreBundle().get());
+            }
 
             result.batchDiagnostics().ifPresent(diag -> {
                 try {

--- a/src/test/java/de/medizininformatikinitiative/torch/service/JobPersistenceServiceTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/service/JobPersistenceServiceTest.java
@@ -1220,6 +1220,44 @@ class JobPersistenceServiceTest {
     }
 
     @Nested
+    class OnBatchProcessingSuccessTests {
+
+        @TempDir
+        Path baseDir;
+
+        @Test
+        void coreBatchWriteIOException_propagatesAndMarksJobTempFailed() throws IOException {
+            FileIo spyIo = spy(new DefaultFileIO());
+            JobPersistenceService service = new JobPersistenceService(spyIo, MAPPER, baseDir.toString(), 5,
+                    new DiagnosticsStore(spyIo, MAPPER));
+            service.init();
+            UUID jobId = service.createJob(EMPTY_PARAMETERS.crtdl(), List.of(), null);
+            service.selectNextWorkUnit();
+            service.onCohortSuccess(jobId, List.of(), Optional.empty());
+
+            ResourceExtractionInfo rei = new ResourceExtractionInfo(
+                    Set.of("G1"),
+                    Map.of("Patient.name", Set.of(ExtractionId.fromRelativeUrl("r/rid-1")))
+            );
+            ExtractionResourceBundle coreBundle = new ExtractionResourceBundle(
+                    new ConcurrentHashMap<>(Map.of(ExtractionId.fromRelativeUrl("r/rid-1"), rei)),
+                    new ConcurrentHashMap<>()
+            );
+            BatchState batchState = BatchState.init();
+            batchState.finishNow(WorkUnitStatus.FINISHED);
+            BatchResult result = new BatchResult(jobId, batchState.batchId(), batchState,
+                    Optional.of(coreBundle), Optional.empty(), List.of());
+
+            doThrow(new IOException("Disk full"))
+                    .when(spyIo).newBufferedWriter(argThat(p -> p.toString().contains("core_batches")));
+
+            service.onBatchProcessingSuccess(result);
+
+            assertThat(service.getJob(jobId).orElseThrow().status()).isEqualTo(JobStatus.TEMP_FAILED);
+        }
+    }
+
+    @Nested
     class UpdateJobAndReturnBranchTests {
 
         @TempDir


### PR DESCRIPTION
## Summary
- `JobPersistenceService.onBatchProcessingSuccess` no longer locally catches the `IOException` from `saveCoreBatch`; it now propagates through `updateJobAndReturn`, same as `saveBatch` in `onCohortSuccess`, so it goes through `onJobError`/`RetryabilityUtil` instead of being logged and ignored.
- The diagnostics-write catch in the same method is intentionally left untouched (diagnostics are best-effort).

## Test plan
- [x] Added `OnBatchProcessingSuccessTests.coreBatchWriteIOException_propagatesAndMarksJobTempFailed`; confirmed it fails against pre-fix code (job stays `RUNNING_PROCESS_CORE`) and passes with the fix (job becomes `TEMP_FAILED`).
- [x] `mvn -Dtest=JobPersistenceServiceTest test` — 92/92 passing.

Closes #1081