### PR TITLE
Fix Discriminator Pattern Matching Only First Value Of Repeating Elements

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/torch/util/DiscriminatorResolver.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/util/DiscriminatorResolver.java
@@ -127,10 +127,12 @@ public class DiscriminatorResolver {
                 if (resolvedChild == null || !resolvedChild.hasValues()) {
                     return false;
                 }
-                Base resolvedChildValue = resolvedChild.getValues().getFirst();
+                // A repeating resolved property (e.g. CodeableConcept.coding) matches a fixed value if any of its
+                // values satisfies it, not only its first - the matching entry need not be first in the source data.
                 Base fixedChildValue = fixedChild.getValues().getFirst();
-                boolean childComparison = compareBaseToFixedOrPattern(resolvedChildValue, fixedChildValue);
-                if (!childComparison) {
+                boolean anyMatch = resolvedChild.getValues().stream()
+                        .anyMatch(resolvedChildValue -> compareBaseToFixedOrPattern(resolvedChildValue, fixedChildValue));
+                if (!anyMatch) {
                     return false;
                 }
             }

--- a/src/main/java/de/medizininformatikinitiative/torch/util/Redaction.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/util/Redaction.java
@@ -280,10 +280,10 @@ public class Redaction {
                 // the values addressed slicing at all, and the per-instance masking above already covers them.
                 if (!matchedSliceIds.isEmpty()) {
                     childContexts.missingRequiredSlices(matchedSliceIds)
-                            .forEach(slice -> addMissingSlice(baseElement, child, slice));
+                            .forEach(slice -> addMissingSlice(baseElement, child, slice, childContexts, references));
                 }
             } else if (child.getMinCardinality() > 0 || childContexts.required()) {
-                addDataAbsentReason(baseElement, child, types.getFirst());
+                addDataAbsentReason(baseElement, child, types.getFirst(), childContexts, references);
             }
         });
     }
@@ -310,27 +310,42 @@ public class Redaction {
      * slice is logged and skipped, since there is no type to build a masked stub from.
      * </p>
      */
-    private void addMissingSlice(Base base, Property child, ElementDefinition slice) {
+    private void addMissingSlice(Base base, Property child, ElementDefinition slice, MultiElementContext childContexts, Map<String, Set<ExtractionId>> references) {
         List<String> sliceTypes = slice.getType().stream().map(ElementDefinition.TypeRefComponent::getWorkingCode).toList();
         if (sliceTypes.isEmpty()) {
             logger.warn("Missing type for required slice {} in field {} of {}", slice.getId(), child.getName(), base.fhirType());
             return;
         }
-        addDataAbsentReason(base, child, sliceTypes.getFirst());
+        // Redact the stub against the missing slice's own element ID rather than the unsliced childContexts, so
+        // requirements the slice adds beyond the base type (e.g. a child required only within this named slice)
+        // are also honored when masking the stub's own children.
+        MultiElementContext sliceContext = new MultiElementContext(slice.getId(),
+                childContexts.contexts().stream().map(ElementContext::definition).toList());
+        addDataAbsentReason(base, child, sliceTypes.getFirst(), sliceContext, references);
     }
 
     /**
      * Adds a DataAbsentReason for a child property of a base.
+     * <p>
+     * A {@code BackboneElement} stub is appended rather than replacing the property outright, so existing
+     * sibling values (e.g. other matched slices already present on a repeating property) are preserved. Its
+     * own required children are then recursively redacted, since a bare {@code data-absent-reason} extension
+     * on the stub does not by itself satisfy the base FHIR cardinality of children such as {@code component.code}.
      *
-     * @param base  the parent of the child
-     * @param child property without values to be checked
-     * @param type  type of the child to be handled
+     * @param base         the parent of the child
+     * @param child        property without values to be checked
+     * @param type         type of the child to be handled
+     * @param childContexts context describing {@code child}, used to redact a BackboneElement stub's own children
+     * @param references   Map of allowed references, forwarded when redacting a BackboneElement stub's children
      */
-    private void addDataAbsentReason(Base base, Property child, String type) {
+    private void addDataAbsentReason(Base base, Property child, String type, MultiElementContext childContexts, Map<String, Set<ExtractionId>> references) {
         type = type.replaceFirst("^[^(|]*[(|]", "");
         try {
             if ("BackboneElement".equals(type)) {
-                ResourceUtils.setField(base, child.getName(), createAbsentReasonExtension(MASKED));
+                Base stub = ResourceUtils.setField(base, child.getName(), createAbsentReasonExtension(MASKED));
+                if (stub != null) {
+                    redactChildren(stub, childContexts, references);
+                }
             } else {
                 Element element = HapiFactory.create(type).addExtension(createAbsentReasonExtension(MASKED));
                 base.setProperty(child.getName(), element);

--- a/src/main/java/de/medizininformatikinitiative/torch/util/ResourceUtils.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/util/ResourceUtils.java
@@ -17,7 +17,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -146,53 +145,56 @@ public class ResourceUtils {
         throw new NoSuchMethodException("No such method with one parameter: " + methodName);
     }
 
-    public static void setField(Base base, String fieldName, Extension extension) {
+    /**
+     * Sets a masked ({@code data-absent-reason}) stub value on the named field of {@code base}, constructing an
+     * instance of the field's declared type via reflection.
+     * <p>
+     * For a repeating ({@code List<T>}) field, the stub is appended via the field's getter rather than replacing
+     * the field through its setter, so any existing values already present on the field are preserved.
+     *
+     * @param base      the resource or element to set the field on
+     * @param fieldName the name of the field to set, used to derive the setter/getter method names
+     * @param extension the {@code data-absent-reason} extension to attach to the created stub
+     * @return the created stub instance, or {@code null} if it could not be created via reflection
+     */
+    public static Base setField(Base base, String fieldName, Extension extension) {
         try {
             String capitalized = fieldName.substring(0, 1).toUpperCase() + fieldName.substring(1);
             String setterName = "set" + capitalized;
 
-
             Method setter = ResourceUtils.getMethodWithOneParam(base, setterName);
-
-
             Type[] genericParameterTypes = setter.getGenericParameterTypes();
 
-            Object valueToSet;
-
             if (genericParameterTypes.length == 1 && genericParameterTypes[0] instanceof ParameterizedType paramType) {
-                // Handle List<T>
+                // Handle List<T>: append via the getter instead of replacing the list through the setter, so
+                // existing sibling values (e.g. other already-matched slices) are not discarded.
                 Type actualType = paramType.getActualTypeArguments()[0];
 
                 Class<?> genericClass = Class.forName(actualType.getTypeName());
-                Object instance = genericClass.getDeclaredConstructor().newInstance();
+                Base instance = (Base) genericClass.getDeclaredConstructor().newInstance();
                 Method addExtension = ResourceUtils.getMethodWithOneParam(instance, "addExtension");
-
-
-                List<Object> list = new ArrayList<>();
                 addExtension.invoke(instance, extension);
-                list.add(instance);
-                valueToSet = list;
 
+                Method getter = base.getClass().getMethod("get" + capitalized);
+                @SuppressWarnings("unchecked")
+                List<Base> list = (List<Base>) getter.invoke(base);
+                list.add(instance);
+                return instance;
             } else {
                 // Handle single object
                 Class<?> paramClass = setter.getParameterTypes()[0];
 
-
-                Object instance = paramClass.getDeclaredConstructor().newInstance();
+                Base instance = (Base) paramClass.getDeclaredConstructor().newInstance();
                 Method addExtension = ResourceUtils.getMethodWithOneParam(instance, "addExtension");
-
-
                 addExtension.invoke(instance, extension);
-                valueToSet = instance;
+
+                setter.invoke(base, instance);
+                return instance;
             }
-
-            // Call the setter
-            setter.invoke(base, valueToSet);
-
-
         } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException |
                  InstantiationException e) {
             logger.error("RESOURCE_REFLECTION_01 Could not set field: {} in class {} due to: {}", fieldName, base.getClass().getSimpleName(), e.getMessage());
+            return null;
         } catch (ClassNotFoundException e) {
             logger.error("RESOURCE_REFLECTION_02 Class not Found for {} {}", fieldName, base.getClass().getSimpleName());
             throw new RuntimeException(e);

--- a/src/test/java/de/medizininformatikinitiative/torch/util/DiscriminatorResolverWithPathTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/util/DiscriminatorResolverWithPathTest.java
@@ -113,6 +113,36 @@ class DiscriminatorResolverWithPathTest {
 
 
     /**
+     * A repeating element (e.g. {@code CodeableConcept.coding}) must match a pattern discriminator if
+     * <i>any</i> of its values satisfies the pattern, not only its first value.
+     */
+    @Test
+    void testResolveDiscriminator_TypeValue_PatternMatchesCodingNotFirstInArray() {
+        when(discriminatorMock.getType()).thenReturn(DiscriminatorType.VALUE);
+        when(discriminatorMock.getPath()).thenReturn("code");
+
+        ElementDefinition slice = new ElementDefinition();
+        slice.setId("Observation.component:SystolicBP");
+
+        ElementDefinition codeElement = new ElementDefinition();
+        CodeableConcept pattern = new CodeableConcept();
+        pattern.addCoding(new Coding("http://loinc.org", "8480-6", null));
+        codeElement.setPattern(pattern);
+        when(snapshotMock.getElementById("Observation.component:SystolicBP.code")).thenReturn(codeElement);
+
+        Observation.ObservationComponentComponent component = new Observation.ObservationComponentComponent();
+        CodeableConcept code = new CodeableConcept();
+        code.addCoding(new Coding("http://snomed.info/sct", "271649006", "Systolic blood pressure (observable entity)"));
+        code.addCoding(new Coding("http://loinc.org", "8480-6", "Blood pressure panel with all children optional"));
+        code.addCoding(new Coding("urn:iso:std:iso:11073:10101", "150017", "Systolic blood pressure"));
+        component.setCode(code);
+
+        Boolean result = DiscriminatorResolver.resolveDiscriminator(component, slice, discriminatorMock, snapshotMock);
+
+        assertTrue(result, "Should match when any coding in the array matches the pattern, not just the first");
+    }
+
+    /**
      * Test when discriminator type is 'VALUE' but the slice does not have a fixed value at the specified path.
      */
     @Test

--- a/src/test/java/de/medizininformatikinitiative/torch/util/RedactionTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/util/RedactionTest.java
@@ -20,6 +20,7 @@ import org.hl7.fhir.r4.model.Medication;
 import org.hl7.fhir.r4.model.Meta;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Quantity;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.StringType;
 import org.junit.jupiter.api.Nested;
@@ -36,6 +37,7 @@ import java.util.Set;
 import static de.medizininformatikinitiative.torch.util.FhirUtil.createAbsentReasonExtension;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 
 public class RedactionTest {
 
@@ -49,6 +51,7 @@ public class RedactionTest {
     public static final String PATIENT = "https://www.medizininformatik-initiative.de/fhir/core/modul-person/StructureDefinition/PatientPseudonymisiert";
     public static final String VITALSTATUS = "https://www.medizininformatik-initiative.de/fhir/core/modul-person/StructureDefinition/Vitalstatus";
     public static final String ENCOUNTER = "https://www.medizininformatik-initiative.de/fhir/core/modul-fall/StructureDefinition/KontaktGesundheitseinrichtung";
+    public static final String BLOOD_PRESSURE = "https://gematik.de/fhir/isik/StructureDefinition/ISiKBlutdruckSystemischArteriell";
 
     private final IntegrationTestSetup integrationTestSetup;
 
@@ -68,6 +71,87 @@ public class RedactionTest {
         DomainResource tgt = integrationTestSetup.redaction().redact(wrapper);
 
         assertThat(fhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(tgt)).isEqualTo(fhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(expected));
+    }
+
+    /**
+     * Reproduces #1168: a component's {@code code.coding} array matches a slice's pattern only if the
+     * matching coding is somewhere in the array, not just at the first position.
+     */
+    @Test
+    void bloodPressureComponentMatchesSliceRegardlessOfCodingOrder() throws RedactionException {
+        Observation observation = new Observation();
+        observation.setId("bp1");
+        Meta meta = new Meta();
+        meta.addProfile(BLOOD_PRESSURE);
+        observation.setMeta(meta);
+
+        Observation.ObservationComponentComponent systolic = observation.addComponent();
+        CodeableConcept systolicCode = new CodeableConcept();
+        systolicCode.addCoding(new Coding("http://snomed.info/sct", "271649006", "Systolic blood pressure (observable entity)"));
+        systolicCode.addCoding(new Coding("http://loinc.org", "8480-6", "Systolic blood pressure"));
+        systolicCode.addCoding(new Coding("urn:iso:std:iso:11073:10101", "150017", "Systolic blood pressure"));
+        systolic.setCode(systolicCode);
+        systolic.setValue(new Quantity().setValue(128).setUnit("millimeter Mercury column").setSystem("http://unitsofmeasure.org").setCode("mm[Hg]"));
+
+        Observation.ObservationComponentComponent diastolic = observation.addComponent();
+        CodeableConcept diastolicCode = new CodeableConcept();
+        diastolicCode.addCoding(new Coding("http://snomed.info/sct", "271650006", "Diastolic blood pressure (observable entity)"));
+        diastolicCode.addCoding(new Coding("http://loinc.org", "8462-4", "Diastolic blood pressure"));
+        diastolicCode.addCoding(new Coding("urn:iso:std:iso:11073:10101", "150018", "Diastolic blood pressure"));
+        diastolic.setCode(diastolicCode);
+        diastolic.setValue(new Quantity().setValue(76).setUnit("millimeter Mercury column").setSystem("http://unitsofmeasure.org").setCode("mm[Hg]"));
+
+        ExtractionRedactionWrapper wrapper = new ExtractionRedactionWrapper(observation, Set.of(BLOOD_PRESSURE), Map.of(), new CopyTreeNode("dummy"));
+        Observation tgt = (Observation) integrationTestSetup.redaction().redact(wrapper);
+
+        assertThat(tgt.getComponent()).hasSize(2);
+        assertThat(tgt.getComponent().get(0).getCode().getCoding())
+                .extracting(Coding::getSystem, Coding::getCode)
+                .contains(tuple("http://snomed.info/sct", "271649006"));
+        assertThat(tgt.getComponent().get(0).getValueQuantity().getValue()).isEqualByComparingTo("128");
+        assertThat(tgt.getComponent().get(0).getValueQuantity().getCode()).isEqualTo("mm[Hg]");
+        assertThat(tgt.getComponent().get(1).getCode().getCoding())
+                .extracting(Coding::getSystem, Coding::getCode)
+                .contains(tuple("http://snomed.info/sct", "271650006"));
+        assertThat(tgt.getComponent().get(1).getValueQuantity().getValue()).isEqualByComparingTo("76");
+        assertThat(tgt.getComponent().get(1).getValueQuantity().getCode()).isEqualTo("mm[Hg]");
+    }
+
+    /**
+     * A required named slice (here {@code DiastolicBP}) entirely absent from the source data gets a masked
+     * stub appended, without discarding already-processed sibling components (e.g. a present {@code SystolicBP}).
+     * The stub's own required children (e.g. {@code code}) are themselves masked rather than left absent,
+     * since a bare {@code data-absent-reason} on the stub alone does not satisfy their base FHIR cardinality.
+     */
+    @Test
+    void missingRequiredSliceAppendsStubWithoutDiscardingExistingComponents() throws RedactionException {
+        Observation observation = new Observation();
+        observation.setId("bp2");
+        Meta meta = new Meta();
+        meta.addProfile(BLOOD_PRESSURE);
+        observation.setMeta(meta);
+
+        Observation.ObservationComponentComponent systolic = observation.addComponent();
+        CodeableConcept systolicCode = new CodeableConcept();
+        systolicCode.addCoding(new Coding("http://snomed.info/sct", "271649006", "Systolic blood pressure (observable entity)"));
+        systolicCode.addCoding(new Coding("http://loinc.org", "8480-6", "Systolic blood pressure"));
+        systolic.setCode(systolicCode);
+        systolic.setValue(new Quantity().setValue(128).setUnit("millimeter Mercury column").setSystem("http://unitsofmeasure.org").setCode("mm[Hg]"));
+        // DiastolicBP (also required by the profile) is intentionally left absent from the source data.
+
+        ExtractionRedactionWrapper wrapper = new ExtractionRedactionWrapper(observation, Set.of(BLOOD_PRESSURE), Map.of(), new CopyTreeNode("dummy"));
+        Observation tgt = (Observation) integrationTestSetup.redaction().redact(wrapper);
+
+        assertThat(tgt.getComponent()).hasSize(2);
+        assertThat(tgt.getComponent().get(0).getCode().getCoding())
+                .extracting(Coding::getSystem, Coding::getCode)
+                .contains(tuple("http://snomed.info/sct", "271649006"));
+        assertThat(tgt.getComponent().get(0).getValueQuantity().getValue()).isEqualByComparingTo("128");
+
+        Observation.ObservationComponentComponent stub = tgt.getComponent().get(1);
+        assertThat(stub.getExtensionsByUrl("http://hl7.org/fhir/StructureDefinition/data-absent-reason")).isNotEmpty();
+        assertThat(stub.hasCode()).isTrue();
+        assertThat(stub.getCode().getExtensionsByUrl("http://hl7.org/fhir/StructureDefinition/data-absent-reason")).isNotEmpty();
     }
 
     @Test
@@ -155,6 +239,9 @@ public class RedactionTest {
         expectedMedication.setMeta(meta);
         Medication.MedicationIngredientComponent ingredient = new Medication.MedicationIngredientComponent();
         ingredient.addExtension(createAbsentReasonExtension("masked"));
+        CodeableConcept item = new CodeableConcept();
+        item.addExtension(createAbsentReasonExtension("masked"));
+        ingredient.setItem(item);
         expectedMedication.setIngredient(List.of(ingredient));
 
 


### PR DESCRIPTION
## Summary

- `DiscriminatorResolver.compareBaseToFixedOrPattern` matched a repeating property (e.g. `CodeableConcept.coding`) against only the *first* value of the resolved data, instead of checking whether any entry matches. Reported symptom: an `Observation.component` whose `code.coding` array listed SNOMED before LOINC never matched its slice's LOINC-only pattern, so the whole component got wiped to a bare `data-absent-reason` stub - dropping the required `code` element (min cardinality 1) and failing DIMP validation. Fixed to match existentially against the resolved side.
- Fixing that made a second, independent, pre-existing bug reachable: `ResourceUtils.setField`, used by `Redaction.addMissingSlice` to mask a required named slice entirely absent from the source (e.g. a missing `DiastolicBP` component), replaced the whole repeating property (`setComponent([stub])`) instead of appending - silently discarding already-processed sibling values. Fixed to append via the getter, and the stub's own required children (e.g. `code`) are now recursively masked too, scoped to the specific missing slice's element definition rather than the unsliced parent.

Deliberately out of scope: `compareBaseToFixedOrPattern` still only checks the first *fixed* pattern value when a pattern specifies more than one (e.g. `Condition.category:todesDiagnose` requires both a SNOMED and a LOINC coding). This is a separate, pre-existing under-validation defect with its own already-established test expectations (`RedactionTest.testMultipleProfiles`, `Todesursache4.json`) - left untouched.

## Test plan

- [x] New unit test on `DiscriminatorResolver` reproducing a pattern match against a non-first array entry (failed before, passes after).
- [x] New `RedactionTest` cases against the real `ISiKBlutdruckSystemischArteriell` profile:
  - Both `SystolicBP` and `DiastolicBP` present with the reported multi-coding order - both components keep their real `code`/`value` content.
  - Only `SystolicBP` present (`DiastolicBP` genuinely missing) - the real component is preserved, and a masked `DiastolicBP` stub is appended with its own `code` masked.
- [x] `RedactionTest.backboneElementHandling` expectation updated: a masked `Medication.ingredient` stub now also carries a masked `item[x]`, per `Medication.ingredient.item[x]` min=1 in the MII SD.
- [x] Full `mvn verify` unit suite: 1146 tests, 0 failures. The 20 errors are exclusively the `*IT` classes needing Docker/Testcontainers, unavailable in this sandbox - unrelated to this change.

Closes #1168