### PR TITLE
Fix NullPointerException In DiscriminatorResolver.resolveType For Unresolvable Type Discriminator Paths

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/torch/util/DiscriminatorResolver.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/util/DiscriminatorResolver.java
@@ -202,8 +202,9 @@ public class DiscriminatorResolver {
 
         ElementDefinition elementContainingInfo = resolveSlicePath(slice, discriminator, snapshot);
 
-        // Check if the element contains any type information
-        if (elementContainingInfo.getType().isEmpty()) {
+        // resolveSlicePath returns null for a non-"$this" path that doesn't resolve in the snapshot, e.g. a
+        // reference-resolving path such as "$this.resolve()".
+        if (elementContainingInfo == null || elementContainingInfo.getType().isEmpty()) {
             return false; // No type information means the type cannot be resolved, so return false
         }
 

--- a/src/test/java/de/medizininformatikinitiative/torch/util/DiscriminatorResolverWithPathTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/util/DiscriminatorResolverWithPathTest.java
@@ -111,6 +111,26 @@ class DiscriminatorResolverWithPathTest {
         assertFalse(result, "Should return false when discriminator path does not exist in the snapshot");
     }
 
+    /**
+     * Test when discriminator type is 'TYPE' and its path does not resolve to an element in the snapshot, as
+     * happens for reference-resolving paths like {@code $this.resolve()} used to slice by the referenced
+     * resource's type. Must return false rather than throw, like the 'VALUE'/'PATTERN' case above already does.
+     */
+    @Test
+    void testResolveDiscriminator_TypeType_PathDoesNotExist() {
+        when(discriminatorMock.getType()).thenReturn(DiscriminatorType.TYPE);
+        when(discriminatorMock.getPath()).thenReturn("$this.resolve()");
+        ElementDefinition slice = new ElementDefinition();
+        slice.setId("Observation.derivedFrom:attached-image");
+        when(snapshotMock.getElementById("Observation.derivedFrom:attached-image.$this.resolve()")).thenReturn(null);
+
+        Reference reference = new Reference("DocumentReference/123");
+
+        Boolean result = DiscriminatorResolver.resolveDiscriminator(reference, slice, discriminatorMock, snapshotMock);
+
+        assertFalse(result, "Should return false, not throw, when a type discriminator's path does not resolve in the snapshot");
+    }
+
 
     /**
      * A repeating element (e.g. {@code CodeableConcept.coding}) must match a pattern discriminator if


### PR DESCRIPTION
## Summary

- `DiscriminatorResolver.resolveType` threw an uncaught `NullPointerException` whenever a `type` discriminator's path wasn't `$this` and didn't resolve to a real element in the profile's snapshot (e.g. a reference-resolving path like `$this.resolve()`). Its sibling method `resolvePattern` already null-guards this exact situation; `resolveType` was missing the same check.
- Reproduced against the real loaded ontology: any resource matching one of the 16 currently-loaded MII pathology / ISiK profile elements using `$this.resolve()` or `resource` paths (`Observation.derivedFrom`/`hasMember`, `DiagnosticReport.basedOn`, `Bundle.entry`) with that field populated would crash redaction with this NPE instead of failing gracefully.
- Fix: add the same `elementContainingInfo == null` guard `resolvePattern` already has, so an unresolvable `type` discriminator path degrades to "does not match this slice" instead of crashing.

This converts the crash into the same silent always-no-match behavior already tracked in #1173 (profile/`.resolve()`-based discriminators aren't evaluable yet) - correct for a crash fix, but those references still won't survive redaction until #1173 is addressed.

## Test plan

- [x] New unit test (`testResolveDiscriminator_TypeType_PathDoesNotExist`) reproducing the NPE for a `type` discriminator with an unresolvable path - failed before the fix, passes after.
- [x] Re-ran the original manual repro against the real `mii-pr-patho-base-observation` profile - now returns `Optional.empty` instead of throwing.
- [x] Targeted suite (`DiscriminatorResolverWithPathTest`, `DiscriminatorResolverWithoutPathTest`, `SlicingTest`, `RedactionTest`, `ResourceUtilsTest`): all pass.

Closes #1172