### PR TITLE
Fix DiscriminatorResolver.resolveType Comparing The Wrong Element's Type

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/torch/util/DiscriminatorResolver.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/util/DiscriminatorResolver.java
@@ -208,8 +208,14 @@ public class DiscriminatorResolver {
             return false; // No type information means the type cannot be resolved, so return false
         }
 
+        Base resolvedBase = resolveElementPath(base, discriminator);
+
+        if (resolvedBase == null) {
+            return false;
+        }
+
         // Proceed with the type comparison
-        return elementContainingInfo.getType().stream().anyMatch(x -> base.fhirType().equalsIgnoreCase(x.getCode()));
+        return elementContainingInfo.getType().stream().anyMatch(x -> resolvedBase.fhirType().equalsIgnoreCase(x.getCode()));
     }
 
 

--- a/src/test/java/de/medizininformatikinitiative/torch/util/DiscriminatorResolverWithPathTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/util/DiscriminatorResolverWithPathTest.java
@@ -133,6 +133,75 @@ class DiscriminatorResolverWithPathTest {
 
 
     /**
+     * Test when discriminator type is 'TYPE' and its path resolves to a child of the sliced element (e.g.
+     * {@code Bundle.entry} sliced by type at path {@code resource}, as done by ISiKBerichtBundle). The type
+     * comparison must use the resolved child's type, not the outer sliced element's own type.
+     */
+    @Test
+    void testResolveDiscriminator_TypeType_PathResolvesToChildResource() {
+        when(discriminatorMock.getType()).thenReturn(DiscriminatorType.TYPE);
+        when(discriminatorMock.getPath()).thenReturn("resource");
+
+        ElementDefinition slice = new ElementDefinition();
+        slice.setId("Bundle.entry:Composition");
+
+        ElementDefinition resourceElement = createElementWithType("Bundle.entry:Composition.resource", "Bundle.entry.resource", "Composition");
+        when(snapshotMock.getElementById("Bundle.entry:Composition.resource")).thenReturn(resourceElement);
+
+        Bundle.BundleEntryComponent entry = new Bundle.BundleEntryComponent();
+        entry.setResource(new Composition());
+
+        Boolean result = DiscriminatorResolver.resolveDiscriminator(entry, slice, discriminatorMock, snapshotMock);
+
+        assertTrue(result, "Should match against the resolved child at the discriminator path, not the outer sliced element itself");
+    }
+
+    /**
+     * Same shape as above, but the child's actual type does not match the slice's declared type.
+     */
+    @Test
+    void testResolveDiscriminator_TypeType_PathResolvesToChildResource_TypeMismatch() {
+        when(discriminatorMock.getType()).thenReturn(DiscriminatorType.TYPE);
+        when(discriminatorMock.getPath()).thenReturn("resource");
+
+        ElementDefinition slice = new ElementDefinition();
+        slice.setId("Bundle.entry:Composition");
+
+        ElementDefinition resourceElement = createElementWithType("Bundle.entry:Composition.resource", "Bundle.entry.resource", "Composition");
+        when(snapshotMock.getElementById("Bundle.entry:Composition.resource")).thenReturn(resourceElement);
+
+        Bundle.BundleEntryComponent entry = new Bundle.BundleEntryComponent();
+        entry.setResource(new Patient());
+
+        Boolean result = DiscriminatorResolver.resolveDiscriminator(entry, slice, discriminatorMock, snapshotMock);
+
+        assertFalse(result, "Should not match when the resolved child's type differs from the slice's declared type");
+    }
+
+    /**
+     * Same shape again, but the discriminator path does not resolve on the actual base instance (e.g. the entry's
+     * {@code resource} is unset). {@code resolveElementPath} then returns null and resolveType must return false
+     * rather than throw a NullPointerException.
+     */
+    @Test
+    void testResolveDiscriminator_TypeType_PathResolvesToChildResource_ChildUnset() {
+        when(discriminatorMock.getType()).thenReturn(DiscriminatorType.TYPE);
+        when(discriminatorMock.getPath()).thenReturn("resource");
+
+        ElementDefinition slice = new ElementDefinition();
+        slice.setId("Bundle.entry:Composition");
+
+        ElementDefinition resourceElement = createElementWithType("Bundle.entry:Composition.resource", "Bundle.entry.resource", "Composition");
+        when(snapshotMock.getElementById("Bundle.entry:Composition.resource")).thenReturn(resourceElement);
+
+        Bundle.BundleEntryComponent entry = new Bundle.BundleEntryComponent();
+
+        Boolean result = DiscriminatorResolver.resolveDiscriminator(entry, slice, discriminatorMock, snapshotMock);
+
+        assertFalse(result, "Should return false, not throw, when the discriminator path does not resolve on the actual base instance");
+    }
+
+    /**
      * A repeating element (e.g. {@code CodeableConcept.coding}) must match a pattern discriminator if
      * <i>any</i> of its values satisfies the pattern, not only its first value.
      */


### PR DESCRIPTION
## Summary

- `DiscriminatorResolver.resolveType` resolved the *expected* type via `resolveSlicePath` but never resolved the *actual* value at the discriminator's path — it always compared `base.fhirType()` (the sliced element instance itself) against the expected type, even when the discriminator path points to one of its children. Its sibling `resolvePattern` already does both halves correctly.
- Confirmed against the real loaded ontology: `ISiKBerichtBundle` slices `Bundle.entry` by `type` discriminator at path `resource`. `Bundle.entry:Composition.resource` is in the snapshot with `type.code = Composition`, but the old code compared it against `base.fhirType()` where `base` is the whole `Bundle.entry`, not its `.resource` child — so it could never match, and `Redaction.handleSlicing` silently wiped the entry's resource content.
- Fix: resolve the actual value via `resolveElementPath(base, discriminator)` (as `resolvePattern` already does) and compare its `fhirType()`, instead of comparing `base.fhirType()` directly. For `path="$this"`, `resolveElementPath` returns `base` itself, so existing passing cases (e.g. `value[x]` type slicing) are unaffected.
- No reference resolution needed here — `Bundle.entry.resource` is an inline child already present in the tree being redacted. This is a local path-walk bug, distinct from the reference-resolution capability gap tracked in #1173.

## Test plan

- [x] New tests in `DiscriminatorResolverWithPathTest` reproducing the `Bundle.entry`/`resource` shape from `ISiKBerichtBundle`: one confirming a match now succeeds, one confirming a genuine type mismatch still correctly fails.
- [x] Verified the positive test fails on the pre-fix code (reverted the fix, re-ran) and passes after.
- [x] Targeted suite (`DiscriminatorResolverWithPathTest`, `DiscriminatorResolverWithoutPathTest`, `SlicingTest`, `RedactionTest`): 63 tests total, all pass.

Closes #1177