### PR TITLE
Fix Slicing.generateConditionsForFHIRPath Emitting Unsubstituted Placeholders For Type And Profile Discriminators

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/torch/util/Slicing.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/util/Slicing.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static de.medizininformatikinitiative.torch.util.DiscriminatorResolver.resolveDiscriminator;
@@ -146,10 +147,10 @@ public class Slicing {
                             break;
                         case TYPE:
                             logger.trace("Type discriminator found");
-                            conditions.add(path + ".ofType({type})");
+                            typeCondition(slicedElement.get(), path, definition).ifPresent(conditions::add);
                             break;
                         case PROFILE:
-                            conditions.add(path + ".conformsTo({profile})");
+                            profileCondition(slicedElement.get(), path).ifPresent(conditions::add);
                             break;
                         default:
                             throw new UnsupportedOperationException("Unsupported discriminator type: " + discriminator.getType());
@@ -159,6 +160,45 @@ public class Slicing {
         }
 
         return conditions;
+    }
+
+    /**
+     * Builds a type-discriminator condition for the given path.
+     * <p>
+     * For {@code $this}, the sliced element's own type constrains the match. For any other path, the type is
+     * looked up on the child element at {@code slicedElement.getId() + "." + path} in the snapshot. Paths that
+     * involve reference resolution (e.g. {@code $this.resolve()}) have no such child element and are left
+     * without a condition rather than guessing, since Torch cannot yet resolve references at this point (#1173).
+     * </p>
+     */
+    private static Optional<String> typeCondition(ElementDefinition slicedElement, String path, CompiledStructureDefinition definition) {
+        Optional<ElementDefinition> typedElement = "$this".equals(path)
+                ? Optional.of(slicedElement)
+                : definition.elementDefinitionById(slicedElement.getId() + "." + path);
+
+        return typedElement.map(element -> element.getType().stream()
+                        .map(ElementDefinition.TypeRefComponent::getCode)
+                        .map(code -> path + ".ofType(" + code + ")")
+                        .collect(Collectors.joining(" or ")))
+                .filter(condition -> !condition.isEmpty());
+    }
+
+    /**
+     * Builds a profile-discriminator condition from the sliced element's own target profile(s).
+     * <p>
+     * Profile discriminators are always reference-resolving in practice (path {@code resolve()} or
+     * {@code $this.resolve()}), so the profile to check against comes from the slice's own {@code Reference}
+     * type rather than from resolving the path itself.
+     * </p>
+     */
+    private static Optional<String> profileCondition(ElementDefinition slicedElement, String path) {
+        String condition = slicedElement.getType().stream()
+                .flatMap(type -> type.getTargetProfile().stream())
+                .map(CanonicalType::getValue)
+                .map(profile -> path + ".conformsTo('" + profile + "')")
+                .collect(Collectors.joining(" or "));
+
+        return condition.isEmpty() ? Optional.empty() : Optional.of(condition);
     }
 
 

--- a/src/test/java/de/medizininformatikinitiative/torch/util/SlicingTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/util/SlicingTest.java
@@ -1,9 +1,14 @@
 package de.medizininformatikinitiative.torch.util;
 
+import ca.uhn.fhir.context.FhirContext;
+import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r4.model.Base;
+import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Composition;
 import org.hl7.fhir.r4.model.ElementDefinition;
+import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.StringType;
 import org.hl7.fhir.r4.model.StructureDefinition;
 import org.hl7.fhir.r4.model.UriType;
@@ -125,7 +130,7 @@ class SlicingTest {
     }
 
     @Test
-    void testGenerateConditionsForFHIRPath_WithUnsupportedDiscriminatorType() {
+    void testGenerateConditionsForFHIRPath_ProfileDiscriminator_NoTypeInfo_ProducesNoCondition() {
         StructureDefinition structureDefinition = new StructureDefinition();
         StructureDefinition.StructureDefinitionSnapshotComponent snapshot = structureDefinition.getSnapshot();
         ElementDefinition elementDefinition = new ElementDefinition();
@@ -137,7 +142,187 @@ class SlicingTest {
 
         List<String> result = Slicing.generateConditionsForFHIRPath("Patient.contact", CompiledStructureDefinition.fromStructureDefinition(structureDefinition));
 
-        assertThat(result).containsExactly("unknown.conformsTo({profile})");
+        assertThat(result).isEmpty();
+    }
+
+    /**
+     * Mirrors {@code Observation.derivedFrom:variant} in the real MII molecular-genetics ontology: a profile
+     * discriminator with a reference-resolving path, where the target profile is declared on the slice's own
+     * {@code Reference} type rather than resolvable via the path itself.
+     */
+    @Test
+    void testGenerateConditionsForFHIRPath_ProfileDiscriminator_SubstitutesTargetProfile() {
+        StructureDefinition structureDefinition = new StructureDefinition();
+        StructureDefinition.StructureDefinitionSnapshotComponent snapshot = structureDefinition.getSnapshot();
+        ElementDefinition parentElement = new ElementDefinition();
+        parentElement.setId("Observation.derivedFrom");
+        parentElement.setPath("Observation.derivedFrom");
+        parentElement.getSlicing().addDiscriminator().setPath("$this.resolve()").setType(ElementDefinition.DiscriminatorType.PROFILE);
+        snapshot.addElement(parentElement);
+        ElementDefinition sliceElement = new ElementDefinition();
+        sliceElement.setId("Observation.derivedFrom:variant");
+        sliceElement.setPath("Observation.derivedFrom");
+        sliceElement.setSliceName("variant");
+        sliceElement.addType().setCode("Reference").addTargetProfile("https://www.medizininformatik-initiative.de/fhir/ext/modul-molgen/StructureDefinition/variante");
+        snapshot.addElement(sliceElement);
+
+        List<String> result = Slicing.generateConditionsForFHIRPath("Observation.derivedFrom:variant",
+                CompiledStructureDefinition.fromStructureDefinition(structureDefinition));
+
+        assertThat(result).containsExactly("$this.resolve().conformsTo('https://www.medizininformatik-initiative.de/fhir/ext/modul-molgen/StructureDefinition/variante')");
+    }
+
+    /**
+     * Mirrors {@code Bundle.entry:Composition} in the real ISiKBerichtBundle ontology: a type discriminator whose
+     * path names a real child element ({@code resource}), whose own type ({@code Composition}) - not the sliced
+     * element's own type ({@code BackboneElement}) - is what the generated condition must check.
+     */
+    @Test
+    void testGenerateConditionsForFHIRPath_TypeDiscriminator_ResolvesChildElementType() {
+        StructureDefinition structureDefinition = new StructureDefinition();
+        StructureDefinition.StructureDefinitionSnapshotComponent snapshot = structureDefinition.getSnapshot();
+        ElementDefinition parentElement = new ElementDefinition();
+        parentElement.setId("Bundle.entry");
+        parentElement.setPath("Bundle.entry");
+        parentElement.getSlicing().addDiscriminator().setPath("resource").setType(ElementDefinition.DiscriminatorType.TYPE);
+        snapshot.addElement(parentElement);
+        ElementDefinition sliceElement = new ElementDefinition();
+        sliceElement.setId("Bundle.entry:Composition");
+        sliceElement.setPath("Bundle.entry");
+        sliceElement.setSliceName("Composition");
+        sliceElement.addType().setCode("BackboneElement");
+        snapshot.addElement(sliceElement);
+        ElementDefinition resourceChild = new ElementDefinition();
+        resourceChild.setId("Bundle.entry:Composition.resource");
+        resourceChild.setPath("Bundle.entry.resource");
+        resourceChild.addType().setCode("Composition");
+        snapshot.addElement(resourceChild);
+
+        List<String> result = Slicing.generateConditionsForFHIRPath("Bundle.entry:Composition",
+                CompiledStructureDefinition.fromStructureDefinition(structureDefinition));
+
+        assertThat(result).containsExactly("resource.ofType(Composition)");
+    }
+
+    /**
+     * A type discriminator with path {@code $this} constrains the sliced element's own type directly (e.g. a
+     * choice-type element like {@code value[x]} sliced by its runtime type), so no child element lookup is
+     * needed.
+     */
+    @Test
+    void testGenerateConditionsForFHIRPath_TypeDiscriminator_ThisPath_UsesSlicedElementOwnType() {
+        StructureDefinition structureDefinition = new StructureDefinition();
+        StructureDefinition.StructureDefinitionSnapshotComponent snapshot = structureDefinition.getSnapshot();
+        ElementDefinition parentElement = new ElementDefinition();
+        parentElement.setId("Observation.value[x]");
+        parentElement.setPath("Observation.value[x]");
+        parentElement.getSlicing().addDiscriminator().setPath("$this").setType(ElementDefinition.DiscriminatorType.TYPE);
+        snapshot.addElement(parentElement);
+        ElementDefinition sliceElement = new ElementDefinition();
+        sliceElement.setId("Observation.value[x]:valueQuantity");
+        sliceElement.setPath("Observation.value[x]");
+        sliceElement.setSliceName("valueQuantity");
+        sliceElement.addType().setCode("Quantity");
+        snapshot.addElement(sliceElement);
+
+        List<String> result = Slicing.generateConditionsForFHIRPath("Observation.value[x]:valueQuantity",
+                CompiledStructureDefinition.fromStructureDefinition(structureDefinition));
+
+        assertThat(result).containsExactly("$this.ofType(Quantity)");
+    }
+
+    /**
+     * A type discriminator whose path resolves to a real child element that itself has no type info produces no
+     * condition, the same as an unresolvable (reference-resolving) path.
+     */
+    @Test
+    void testGenerateConditionsForFHIRPath_TypeDiscriminator_ChildFound_NoTypeInfo_ProducesNoCondition() {
+        StructureDefinition structureDefinition = new StructureDefinition();
+        StructureDefinition.StructureDefinitionSnapshotComponent snapshot = structureDefinition.getSnapshot();
+        ElementDefinition parentElement = new ElementDefinition();
+        parentElement.setId("Bundle.entry");
+        parentElement.setPath("Bundle.entry");
+        parentElement.getSlicing().addDiscriminator().setPath("resource").setType(ElementDefinition.DiscriminatorType.TYPE);
+        snapshot.addElement(parentElement);
+        ElementDefinition sliceElement = new ElementDefinition();
+        sliceElement.setId("Bundle.entry:Untyped");
+        sliceElement.setPath("Bundle.entry");
+        sliceElement.setSliceName("Untyped");
+        snapshot.addElement(sliceElement);
+        ElementDefinition resourceChild = new ElementDefinition();
+        resourceChild.setId("Bundle.entry:Untyped.resource");
+        resourceChild.setPath("Bundle.entry.resource");
+        snapshot.addElement(resourceChild);
+
+        List<String> result = Slicing.generateConditionsForFHIRPath("Bundle.entry:Untyped",
+                CompiledStructureDefinition.fromStructureDefinition(structureDefinition));
+
+        assertThat(result).isEmpty();
+    }
+
+    /**
+     * Confirms the fix's core motivation: the generated {@code .where(...)} clause for a type discriminator is
+     * valid FHIRPath that evaluates without throwing (unlike the unsubstituted {@code {type}} placeholder), and
+     * actually filters by the resolved child type.
+     */
+    @Test
+    void testHandleSlicingForFhirPath_TypeDiscriminator_EvaluatesWithoutThrowing() throws FHIRException {
+        StructureDefinition structureDefinition = new StructureDefinition();
+        StructureDefinition.StructureDefinitionSnapshotComponent snapshot = structureDefinition.getSnapshot();
+        ElementDefinition parentElement = new ElementDefinition();
+        parentElement.setId("Bundle.entry");
+        parentElement.setPath("Bundle.entry");
+        parentElement.getSlicing().addDiscriminator().setPath("resource").setType(ElementDefinition.DiscriminatorType.TYPE);
+        snapshot.addElement(parentElement);
+        ElementDefinition sliceElement = new ElementDefinition();
+        sliceElement.setId("Bundle.entry:Composition");
+        sliceElement.setPath("Bundle.entry");
+        sliceElement.setSliceName("Composition");
+        sliceElement.addType().setCode("BackboneElement");
+        snapshot.addElement(sliceElement);
+        ElementDefinition resourceChild = new ElementDefinition();
+        resourceChild.setId("Bundle.entry:Composition.resource");
+        resourceChild.setPath("Bundle.entry.resource");
+        resourceChild.addType().setCode("Composition");
+        snapshot.addElement(resourceChild);
+
+        String[] fhirPath = FhirPathBuilder.handleSlicingForFhirPath("Bundle.entry:Composition",
+                CompiledStructureDefinition.fromStructureDefinition(structureDefinition));
+
+        Bundle bundle = new Bundle();
+        bundle.addEntry().setResource(new Composition());
+        bundle.addEntry().setResource(new Patient());
+
+        List<Base> matches = FhirContext.forR4().newFhirPath().evaluate(bundle, fhirPath[0], Base.class);
+
+        assertThat(matches).hasSize(1);
+    }
+
+    /**
+     * A type discriminator whose path involves reference resolution (e.g. {@code $this.resolve()}) has no child
+     * element to look up statically - Torch cannot yet resolve references at this point (#1173) - so no condition
+     * should be generated rather than a fabricated, always-false one.
+     */
+    @Test
+    void testGenerateConditionsForFHIRPath_TypeDiscriminator_UnresolvablePath_ProducesNoCondition() {
+        StructureDefinition structureDefinition = new StructureDefinition();
+        StructureDefinition.StructureDefinitionSnapshotComponent snapshot = structureDefinition.getSnapshot();
+        ElementDefinition parentElement = new ElementDefinition();
+        parentElement.setId("Observation.derivedFrom");
+        parentElement.setPath("Observation.derivedFrom");
+        parentElement.getSlicing().addDiscriminator().setPath("$this.resolve()").setType(ElementDefinition.DiscriminatorType.TYPE);
+        snapshot.addElement(parentElement);
+        ElementDefinition sliceElement = new ElementDefinition();
+        sliceElement.setId("Observation.derivedFrom:attachedImage");
+        sliceElement.setPath("Observation.derivedFrom");
+        sliceElement.setSliceName("attachedImage");
+        sliceElement.addType().setCode("Reference");
+        snapshot.addElement(sliceElement);
+
+        List<String> result = Slicing.generateConditionsForFHIRPath("Observation.derivedFrom:attachedImage",
+                CompiledStructureDefinition.fromStructureDefinition(structureDefinition));
+
+        assertThat(result).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `Slicing.generateConditionsForFHIRPath`'s `TYPE`/`PROFILE` discriminator cases emitted literal, unsubstituted placeholder text (`.ofType({type})` / `.conformsTo({profile})`) instead of real values. This text is invalid FHIRPath and gets fed straight into a real HAPI FHIRPath engine at extraction time (`ReferenceExtractor`, `ElementCopier`, `ProfileMustHaveChecker`), throwing on evaluation. `ReferenceExtractor` runs inside `ReferenceResolver.loadReferencesByResourceGroup`'s `.parallelStream()`, so one affected resource could abort reference resolution for a whole batch.
- Confirmed live against the loaded ontology: `Observation.derivedFrom:variant` in `mii-pr-molgen-diagnostische-implikation` is sliced with a `profile` discriminator, so any CRTDL attribute referencing that slice generated a broken `.where(...)` clause.

## Fix

- **`PROFILE`**: substitute the target profile URL(s) from the slice's own `Reference` type (`ElementDefinition.getType().get(i).getTargetProfile()`). Verified against the real ontology that every `profile` discriminator currently in use is reference-resolving (`resolve()`/`$this.resolve()`), so the profile constraint always lives on the slice's own type, never on a literal child element.
- **`TYPE`**: for path `$this`, use the sliced element's own type. For any other path, look up the child element at `slicedElement.getId() + "." + path` in the snapshot and use *its* type. This mirrors `DiscriminatorResolver.resolveSlicePath`'s existing pattern (from #1177/#1178) and matters concretely: `Bundle.entry:Composition` (ISiKBerichtBundle, discriminator path `resource`) has its own type as `BackboneElement`, while the real constraint (`Composition`) lives on the child `Bundle.entry:Composition.resource`. Naively substituting the slice's own type, as a literal reading of the placeholder text might suggest, would have produced a syntactically valid but always-false condition — the same defect class just fixed in #1178.
- **Reference-resolving `TYPE` paths** (`$this.resolve()`, e.g. `Observation.derivedFrom`/`hasMember` in the pathology module) have no literal child element to look up. Rather than fabricate an incorrect condition, no condition is generated for that discriminator and the `.where(...)` clause falls back to any remaining discriminators (or no filtering, if it was the only one) — the same fail-open behavior already accepted for `resolvePattern`'s valueset-binding gap. Full support for resolving through references is tracked separately in #1173, which is scoped to land first; this PR does not touch that capability.

## Test plan

- `SlicingTest`: added cases for `PROFILE` substitution (real `Observation.derivedFrom:variant` shape), `PROFILE`/`TYPE` with no type info (no condition), `TYPE` via child-path resolution (real `Bundle.entry:Composition` shape), `TYPE` via `$this`, and `TYPE` with an unresolvable (reference-resolving) path.
- Added a focused test evaluating the generated `.where(...)` expression through a real `IFhirPath` engine against a `Bundle` with `Composition`/`Patient` entries, confirming it no longer throws and correctly filters to the matching entry.
- Full `SlicingTest`, `FhirPathBuilderTest`, `ProfileMustHaveCheckerTest`, `ReferenceExtractorTest`, `ElementCopierTest`: 70 tests, all pass.

Closes #1179