### PR TITLE
Harden Profile Validation In Redaction.redact Against Substring Collisions

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/torch/util/Redaction.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/util/Redaction.java
@@ -106,9 +106,8 @@ public class Redaction {
         List<CanonicalType> resourceProfiles;
         if (!resource.getResourceType().toString().equals("Patient")) {
             // Convert resource profiles to a list of strings
-            resourceProfiles = meta.getProfile().stream().filter(profile -> wrapper.profiles().stream().anyMatch(wrapperProfile -> profile.toString().contains(wrapperProfile))).toList();
-            List<CanonicalType> finalResourceProfiles = resourceProfiles;
-            Set<String> validProfiles = wrapper.profiles().stream().filter(profile -> finalResourceProfiles.stream().anyMatch(resourceProfile -> resourceProfile.toString().contains(profile))).collect(Collectors.toSet());
+            resourceProfiles = meta.getProfile().stream().filter(profile -> wrapper.profiles().contains(ResourceUtils.stripVersion(profile.getValue()))).toList();
+            Set<String> validProfiles = resourceProfiles.stream().map(profile -> ResourceUtils.stripVersion(profile.getValue())).collect(Collectors.toSet());
 
             if (!validProfiles.equals(wrapper.profiles())) {
                 logger.error("REDACTION_01 Missing Profiles in Resource {} {}: {} for requested profiles {}", resource.getResourceType(), resource.getId(), resourceProfiles, wrapper.profiles());

--- a/src/test/java/de/medizininformatikinitiative/torch/util/RedactionTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/util/RedactionTest.java
@@ -17,6 +17,7 @@ import org.hl7.fhir.r4.model.Encounter;
 import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Medication;
+import org.hl7.fhir.r4.model.MedicationAdministration;
 import org.hl7.fhir.r4.model.Meta;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Patient;
@@ -115,6 +116,45 @@ public class RedactionTest {
                 .contains(tuple("http://snomed.info/sct", "271650006"));
         assertThat(tgt.getComponent().get(1).getValueQuantity().getValue()).isEqualByComparingTo("76");
         assertThat(tgt.getComponent().get(1).getValueQuantity().getCode()).isEqualTo("mm[Hg]");
+    }
+
+    /**
+     * Reproduces #1174: {@code Redaction.redact} validated declared profiles against requested profiles with a
+     * substring check, so a resource declaring an unrelated profile that happens to be a literal superstring of
+     * the requested one (e.g. {@code MedicationAdministration} containing {@code Medication}) passed validation
+     * instead of being rejected as a profile mismatch.
+     */
+    @Test
+    void profileValidationRejectsPrefixCollidingProfile() {
+        MedicationAdministration resource = new MedicationAdministration();
+        resource.setId("ma1");
+        Meta meta = new Meta();
+        meta.addProfile("https://www.medizininformatik-initiative.de/fhir/core/modul-medikation/StructureDefinition/MedicationAdministration");
+        resource.setMeta(meta);
+
+        ExtractionRedactionWrapper wrapper = new ExtractionRedactionWrapper(resource, Set.of(MEDICATION), Map.of(), new CopyTreeNode("dummy"));
+
+        assertThatThrownBy(() -> integrationTestSetup.redaction().redact(wrapper))
+                .isInstanceOf(RedactionException.class);
+    }
+
+    /**
+     * The exact-match fix for #1174 must remain tolerant of version-suffixed profile URLs, which was the
+     * original (if imprecise) purpose of the substring check it replaces.
+     */
+    @Test
+    void profileValidationAcceptsVersionedProfileSuffix() throws RedactionException {
+        Medication resource = new Medication();
+        resource.setId("med1");
+        Meta meta = new Meta();
+        meta.addProfile(MEDICATION + "|1.2.0");
+        resource.setMeta(meta);
+
+        ExtractionRedactionWrapper wrapper = new ExtractionRedactionWrapper(resource, Set.of(MEDICATION), Map.of(), new CopyTreeNode("dummy"));
+
+        DomainResource tgt = integrationTestSetup.redaction().redact(wrapper);
+
+        assertThat(tgt.getMeta().getProfile()).extracting(CanonicalType::getValue).containsExactly(MEDICATION + "|1.2.0");
     }
 
     /**


### PR DESCRIPTION
## Summary

- `Redaction.redact` validated a resource's declared `meta.profile` entries against the requested profiles using `String.contains` rather than an exact match, apparently to tolerate version suffixes (`...StructureDefinition/Foo|1.2.0` containing the unversioned `...StructureDefinition/Foo`). But `.contains` also matches when one profile's canonical URL is a literal prefix of a completely unrelated profile's URL.
- 44 such prefix-colliding pairs exist in the current ontology, including same-module cases like `.../modul-medikation/StructureDefinition/Medication` prefixing `MedicationAdministration`, `MedicationRequest`, and `MedicationStatement`.
- Not confirmed exploitable via the standard pipeline today (`wrapper.profiles()` is built from a resource's own already-matched attribute groups, so a single resource isn't expected to carry two colliding-but-unrelated profiles) — but it's a fragile equality check that would misbehave silently if ever triggered, with no exception raised.

## Fix

Replace the substring check with an exact match on the version-stripped URL, using `ResourceUtils.stripVersion` (already used elsewhere for the same purpose, e.g. `StructureDefinitionHandler.getDefinition`).

## Test plan

- Added `profileValidationRejectsPrefixCollidingProfile`: a resource declaring only `MedicationAdministration` as its profile, requested against `Set.of(MEDICATION)`, must be rejected as a profile mismatch (`RedactionException`).
  - Verified empirically against the pre-fix code by temporarily reverting the fix: the test *fails* pre-fix (no exception is raised — the collision silently passes validation), confirming the bug is real and this test reproduces it. Note: the issue's original verification plan text said this case "should throw both before and after the fix" — that doesn't hold; the whole point of the bug is that the substring check silently *passes* this exact case pre-fix, matching the issue's own "Reachability" section ("misbehave silently ... with no exception raised").
- Added `profileValidationAcceptsVersionedProfileSuffix`: confirms the fix remains tolerant of version-suffixed profile URLs (`Medication|1.2.0` still matches a request for unversioned `Medication`), preserving the substring check's original intent.
- Full `RedactionTest`: 42 tests, all pass.

Closes #1174