### PR TITLE
Release v1.0.0-beta.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+## [v1.0.0-beta.7.2] - 2026-08-09
+
+### Added
+
+- Add Heap Warn Log [#1147](https://github.com/medizininformatik-initiative/torch/pull/1147)
+- Verify Cohort Patient Count Against Exclusions And Final Patients [#1151](https://github.com/medizininformatik-initiative/torch/pull/1151)
+- Expose Torch Prometheus Metrics Endpoint [#1156](https://github.com/medizininformatik-initiative/torch/pull/1156)
+- Add Positive Outcome To Diagnostics [#1166](https://github.com/medizininformatik-initiative/torch/pull/1166)
+
+### Changed
+
+- Improve Job Diagnostics [#1089](https://github.com/medizininformatik-initiative/torch/pull/1089)
+- Hand Must Have Violation Information Over In Cascading Delete [#1152](https://github.com/medizininformatik-initiative/torch/pull/1152)
+- Extend Diagnostics [#1154](https://github.com/medizininformatik-initiative/torch/pull/1154)
+- Extract Consent Source Data and Encounter Metadata Separately [#1161](https://github.com/medizininformatik-initiative/torch/pull/1161)
+- Extend PatientListParams [#1169](https://github.com/medizininformatik-initiative/torch/pull/1169)
+- Update hapi to v6.10.1 [#1176](https://github.com/medizininformatik-initiative/torch/pull/1176)
+
+### Fixed
+
+- Fix Core Batch Write Failures Being Silently Swallowed in JobPersistenceService [#1170](https://github.com/medizininformatik-initiative/torch/pull/1170)
+- Fix Discriminator Pattern Matching Only First Value Of Repeating Elements [#1171](https://github.com/medizininformatik-initiative/torch/pull/1171)
+- Fix NullPointerException In DiscriminatorResolver.resolveType For Unresolvable Type Discriminator Paths [#1175](https://github.com/medizininformatik-initiative/torch/pull/1175)
+
+
 ## [v1.0.0-beta.7.1] - 2026-08-03
 
 ### Fixed

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -178,17 +178,17 @@ For container images, we use cosign to sign images. This allows users to confirm
 pipeline and has not been modified after publication.
 
 ```
-cosign verify "ghcr.io/medizininformatik-initiative/torch:v1.0.0-beta.7.1" \
+cosign verify "ghcr.io/medizininformatik-initiative/torch:v1.0.0-beta.7.2" \
 --certificate-identity-regexp "https://github.com/medizininformatik-initiative/torch.*" \
 --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
---certificate-github-workflow-ref="refs/tags/v1.0.0-beta.7.1" \
+--certificate-github-workflow-ref="refs/tags/v1.0.0-beta.7.2" \
 -o text
 ```
 
 The expected output is:
 
 ```
-Verification for ghcr.io/medizininformatik-initiative/torch:v1.0.0-beta.7.1 --
+Verification for ghcr.io/medizininformatik-initiative/torch:v1.0.0-beta.7.2 --
 The following checks were performed on each of these signatures:
 - The cosign claims were validated
 - Existence of the claims in the transparency log was verified offline
@@ -196,5 +196,5 @@ The following checks were performed on each of these signatures:
 ```
 
 This output ensures that the image was build on the GitHub workflow on the repository
-`medizininformatik-initiative/torch` and tag `v1.0.0-beta.7.1`.
+`medizininformatik-initiative/torch` and tag `v1.0.0-beta.7.2`.
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>de.medizininformatikinitiative</groupId>
     <artifactId>torch</artifactId>
-    <version>v1.0.0-beta.7.1</version>
+    <version>v1.0.0-beta.7.2</version>
 
     <properties>
         <maven.compiler.source>21</maven.compiler.source>

--- a/src/main/java/de/medizininformatikinitiative/torch/rest/CapabilityStatementController.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/rest/CapabilityStatementController.java
@@ -52,7 +52,7 @@ public class CapabilityStatementController {
         capabilityStatement.setDate(new java.util.Date());
         capabilityStatement.setFhirVersion(Enumerations.FHIRVersion._4_0_1);
         capabilityStatement.setKind(CapabilityStatement.CapabilityStatementKind.INSTANCE);
-        capabilityStatement.getSoftware().setName("Torch FHIR Server").setVersion("1.0.0-beta.7");
+        capabilityStatement.getSoftware().setName("Torch FHIR Server").setVersion("1.0.0-beta.7.2");
         capabilityStatement.getImplementation().setDescription("Torch FHIR Server Implementation");
         logger.trace("Created basic metadata for CapabilityStatement");
 


### PR DESCRIPTION
## Summary

Prerelease containing the ISiK blood-pressure discriminator fix (#1171) that Charité needs for SOMNOLINK, plus everything else merged to main since v1.0.0-beta.7.1.

## Test plan

- [ ] CI (build/test/blackbox/image-scan) passes
- [ ] Merge, tag `v1.0.0-beta.7.2` on the merge commit, mark GitHub Release as prerelease