### PR TITLE
Support Profile And Reference-Resolving Type Discriminators In Slicing

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/torch/model/management/ElementContext.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/model/management/ElementContext.java
@@ -10,11 +10,13 @@ import java.util.stream.Stream;
 
 import static java.util.Objects.requireNonNull;
 
-public record ElementContext(String elementId, CompiledStructureDefinition definition) {
+public record ElementContext(String elementId, CompiledStructureDefinition definition,
+                             ReferenceResolutionContext resolutionContext) {
 
     public ElementContext {
         requireNonNull(elementId);
         requireNonNull(definition);
+        requireNonNull(resolutionContext);
     }
 
     Optional<ElementDefinition> elementDefinition() {
@@ -29,7 +31,7 @@ public record ElementContext(String elementId, CompiledStructureDefinition defin
      * @return ElementContext with elementIds updated by one step.
      */
     ElementContext descend(String childName) {
-        return new ElementContext(elementId + "." + childName, definition);
+        return new ElementContext(elementId + "." + childName, definition, resolutionContext);
     }
 
     /**
@@ -42,8 +44,8 @@ public record ElementContext(String elementId, CompiledStructureDefinition defin
     }
 
     public Optional<ElementContext> matchingSlice(Base dataElement) {
-        Optional<ElementDefinition> slice = Slicing.resolveSlicing(dataElement, elementId, definition);
-        return slice.map(elementDefinition -> new ElementContext(elementDefinition.getId(), definition));
+        Optional<ElementDefinition> slice = Slicing.resolveSlicing(dataElement, elementId, definition, resolutionContext);
+        return slice.map(elementDefinition -> new ElementContext(elementDefinition.getId(), definition, resolutionContext));
     }
 
     /**

--- a/src/main/java/de/medizininformatikinitiative/torch/model/management/ExtractionRedactionWrapper.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/model/management/ExtractionRedactionWrapper.java
@@ -4,35 +4,47 @@ import de.medizininformatikinitiative.torch.exceptions.RedactionException;
 import de.medizininformatikinitiative.torch.model.extraction.ExtractionId;
 import org.hl7.fhir.r4.model.CanonicalType;
 import org.hl7.fhir.r4.model.DomainResource;
+import org.hl7.fhir.r4.model.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
  * Contains all information needed for the extraction and redaction operations, and pairs a resource
  * with the profiles it is required to satisfy.
  *
- * @param resource   Resource to be processed
- * @param profiles   profiles of structure definitions of the applied groups
- * @param references map from elementid to reference string
- * @param copyTree   merged attribute copy tree for the extraction
+ * @param resource          Resource to be processed
+ * @param profiles          profiles of structure definitions of the applied groups
+ * @param references        map from elementid to reference string
+ * @param copyTree          merged attribute copy tree for the extraction
+ * @param referenceResolver looks up an already-resolved resource by {@link ExtractionId}, used to evaluate a
+ *                          {@code resolve()} step in a slicing discriminator path; empty if unresolved
  */
 public record ExtractionRedactionWrapper(DomainResource resource, Set<String> profiles,
                                          Map<String, Set<ExtractionId>> references,
-                                         CopyTreeNode copyTree) {
+                                         CopyTreeNode copyTree,
+                                         Function<ExtractionId, Optional<Resource>> referenceResolver) {
 
     private static final Logger logger = LoggerFactory.getLogger(ExtractionRedactionWrapper.class);
 
     public ExtractionRedactionWrapper {
         Objects.requireNonNull(resource);
         Objects.requireNonNull(copyTree);
+        Objects.requireNonNull(referenceResolver);
         profiles = Set.copyOf(profiles);
         references = Map.copyOf(references);
+    }
+
+    public ExtractionRedactionWrapper(DomainResource resource, Set<String> profiles,
+                                      Map<String, Set<ExtractionId>> references, CopyTreeNode copyTree) {
+        this(resource, profiles, references, copyTree, id -> Optional.empty());
     }
 
     /**
@@ -46,7 +58,23 @@ public record ExtractionRedactionWrapper(DomainResource resource, Set<String> pr
     public static ExtractionRedactionWrapper of(DomainResource resource, Set<String> profiles,
                                                  Map<String, Set<ExtractionId>> references,
                                                  CopyTreeNode copyTree) throws RedactionException {
-        ExtractionRedactionWrapper wrapper = new ExtractionRedactionWrapper(resource, profiles, references, copyTree);
+        return of(resource, profiles, references, copyTree, id -> Optional.empty());
+    }
+
+    /**
+     * Builds a wrapper with an explicit {@code referenceResolver}, validating that {@code resource} actually
+     * carries every profile in {@code profiles}.
+     * <p>
+     * {@code Patient} resources are exempt, since their profiles are assigned by the caller rather than
+     * read off the resource.
+     *
+     * @throws RedactionException if a non-{@code Patient} resource is missing one or more required profiles
+     */
+    public static ExtractionRedactionWrapper of(DomainResource resource, Set<String> profiles,
+                                                 Map<String, Set<ExtractionId>> references,
+                                                 CopyTreeNode copyTree,
+                                                 Function<ExtractionId, Optional<Resource>> referenceResolver) throws RedactionException {
+        ExtractionRedactionWrapper wrapper = new ExtractionRedactionWrapper(resource, profiles, references, copyTree, referenceResolver);
 
         if (!resource.getResourceType().toString().equals("Patient")) {
             List<CanonicalType> resourceProfiles = wrapper.matchedProfiles();
@@ -74,7 +102,7 @@ public record ExtractionRedactionWrapper(DomainResource resource, Set<String> pr
     }
 
     public ExtractionRedactionWrapper updateWithResource(DomainResource resource) throws RedactionException {
-        return ExtractionRedactionWrapper.of(resource, profiles, references, copyTree);
+        return ExtractionRedactionWrapper.of(resource, profiles, references, copyTree, referenceResolver);
     }
 
 }

--- a/src/main/java/de/medizininformatikinitiative/torch/model/management/MultiElementContext.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/model/management/MultiElementContext.java
@@ -20,8 +20,16 @@ public record MultiElementContext(List<ElementContext> contexts) {
         contexts = List.copyOf(contexts);
     }
 
-    public MultiElementContext(String elementId, List<CompiledStructureDefinition> definitions) {
-        this(definitions.stream().map(compiledStructureDefinition -> new ElementContext(elementId, compiledStructureDefinition)).toList());
+    public MultiElementContext(String elementId, List<CompiledStructureDefinition> definitions, ReferenceResolutionContext resolutionContext) {
+        this(definitions.stream().map(compiledStructureDefinition -> new ElementContext(elementId, compiledStructureDefinition, resolutionContext)).toList());
+    }
+
+    /**
+     * The {@link ReferenceResolutionContext} shared by all contained {@link ElementContext}s, or
+     * {@link ReferenceResolutionContext#EMPTY} if this instance holds none.
+     */
+    public ReferenceResolutionContext resolutionContext() {
+        return contexts.isEmpty() ? ReferenceResolutionContext.EMPTY : contexts.getFirst().resolutionContext();
     }
 
     /**

--- a/src/main/java/de/medizininformatikinitiative/torch/model/management/ReferenceResolutionContext.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/model/management/ReferenceResolutionContext.java
@@ -1,0 +1,24 @@
+package de.medizininformatikinitiative.torch.model.management;
+
+import de.medizininformatikinitiative.torch.model.extraction.ExtractionId;
+import de.medizininformatikinitiative.torch.util.CompiledStructureDefinition;
+import org.hl7.fhir.r4.model.Resource;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Bundles the lookups {@link de.medizininformatikinitiative.torch.util.DiscriminatorResolver} needs to evaluate
+ * discriminator paths that resolve an external {@link org.hl7.fhir.r4.model.Reference} (e.g. {@code $this.resolve()}).
+ *
+ * @param referenceResolver looks up an already-resolved resource by its {@link ExtractionId}; empty if unresolved
+ * @param profileResolver   looks up the {@link CompiledStructureDefinition} for a profile canonical URL; empty if
+ *                          the profile is not locally known (e.g. a base HL7 canonical URL, which isn't loaded as
+ *                          an MII ontology profile)
+ */
+public record ReferenceResolutionContext(Function<ExtractionId, Optional<Resource>> referenceResolver,
+                                          Function<String, Optional<CompiledStructureDefinition>> profileResolver) {
+
+    public static final ReferenceResolutionContext EMPTY =
+            new ReferenceResolutionContext(id -> Optional.empty(), url -> Optional.empty());
+}

--- a/src/main/java/de/medizininformatikinitiative/torch/service/BatchCopierRedacter.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/service/BatchCopierRedacter.java
@@ -68,6 +68,9 @@ public class BatchCopierRedacter {
      */
     public ExtractionResourceBundle transformBundle(ExtractionResourceBundle extractionBundle, Map<String, AnnotatedAttributeGroup> groupMap) {
         Map<ExtractionId, ResourceExtractionInfo> infoMap = extractionBundle.extractionInfoMap();
+        // Snapshot the pre-redaction cache: discriminator resolve() lookups must see the resources as extracted,
+        // not racing against other threads in this same parallelStream() concurrently redacting them in place.
+        Map<ExtractionId, Optional<Resource>> preRedactionCache = Map.copyOf(extractionBundle.cache());
 
         infoMap.keySet().parallelStream().forEach(resourceId -> {
             Optional<Resource> opt = extractionBundle.getResource(resourceId);
@@ -80,7 +83,7 @@ public class BatchCopierRedacter {
 
             try {
                 ExtractionRedactionWrapper wrapper =
-                        createWrapper(resource, info, groupMap);
+                        createWrapper(resource, info, groupMap, preRedactionCache);
 
                 Resource transformed = transformResource(wrapper);
 
@@ -98,7 +101,8 @@ public class BatchCopierRedacter {
     ExtractionRedactionWrapper createWrapper(
             Resource resource,
             ResourceExtractionInfo info,
-            Map<String, AnnotatedAttributeGroup> groupMap
+            Map<String, AnnotatedAttributeGroup> groupMap,
+            Map<ExtractionId, Optional<Resource>> referenceLookup
     ) throws RedactionException {
         CopyTreeNode copyTree = new CopyTreeNode(resource.getClass().getSimpleName());
         Set<String> groupProfiles = new HashSet<>();
@@ -115,7 +119,8 @@ public class BatchCopierRedacter {
                 (DomainResource) resource,
                 groupProfiles,
                 info.attributeToReferences(),
-                copyTree
+                copyTree,
+                id -> referenceLookup.getOrDefault(id, Optional.empty())
         );
     }
 

--- a/src/main/java/de/medizininformatikinitiative/torch/util/DiscriminatorResolver.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/util/DiscriminatorResolver.java
@@ -1,9 +1,14 @@
 package de.medizininformatikinitiative.torch.util;
 
+import de.medizininformatikinitiative.torch.model.extraction.ExtractionId;
+import de.medizininformatikinitiative.torch.model.management.ReferenceResolutionContext;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r4.model.Base;
+import org.hl7.fhir.r4.model.CanonicalType;
 import org.hl7.fhir.r4.model.ElementDefinition;
 import org.hl7.fhir.r4.model.Property;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.StructureDefinition;
 import org.hl7.fhir.r4.model.Type;
 import org.slf4j.Logger;
@@ -11,6 +16,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Resolves Slicing Discriminators. Essential for handling slicing
@@ -22,17 +29,19 @@ public class DiscriminatorResolver {
     /**
      * Resolves the discriminator for a given slice
      *
-     * @param base          Element to be sliced
-     * @param slice         ElementDefinition of the slice
-     * @param discriminator Discriminator to be resolved
-     * @param snapshot      Snapshot of the StructureDefinition
+     * @param base              Element to be sliced
+     * @param slice             ElementDefinition of the slice
+     * @param discriminator     Discriminator to be resolved
+     * @param snapshot          Snapshot of the StructureDefinition
+     * @param resolutionContext lookups needed to evaluate a {@code resolve()} step in the discriminator path
      * @return true if Discriminator could be resolved, false otherwise
      */
-    public static Boolean resolveDiscriminator(Base base, ElementDefinition slice, ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent discriminator, StructureDefinition.StructureDefinitionSnapshotComponent snapshot) {
+    public static Boolean resolveDiscriminator(Base base, ElementDefinition slice, ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent discriminator, StructureDefinition.StructureDefinitionSnapshotComponent snapshot, ReferenceResolutionContext resolutionContext) {
         return switch (discriminator.getType().toCode()) {
             case "pattern", "value" ->
-                    resolvePattern(base, slice, discriminator, snapshot); //pattern is deprecated and functionally equal to value
-            case "type" -> resolveType(base, slice, discriminator, snapshot);
+                    resolvePattern(base, slice, discriminator, snapshot, resolutionContext); //pattern is deprecated and functionally equal to value
+            case "type" -> resolveType(base, slice, discriminator, snapshot, resolutionContext);
+            case "profile" -> resolveProfile(base, slice, discriminator, resolutionContext);
             default -> false;
         };
     }
@@ -62,7 +71,8 @@ public class DiscriminatorResolver {
      */
     private static Boolean resolvePattern(Base base, ElementDefinition slice,
                                           ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent discriminator,
-                                          StructureDefinition.StructureDefinitionSnapshotComponent snapshot) {
+                                          StructureDefinition.StructureDefinitionSnapshotComponent snapshot,
+                                          ReferenceResolutionContext resolutionContext) {
 
         ElementDefinition elementContainingInfo = resolveSlicePath(slice, discriminator, snapshot);
 
@@ -71,7 +81,7 @@ public class DiscriminatorResolver {
             return false;
         }
 
-        Base resolvedBase = resolveElementPath(base, discriminator);
+        Base resolvedBase = resolveElementPath(base, discriminator, resolutionContext);
 
         if (resolvedBase == null) {
             logger.trace("Could not resolve base {}", base);
@@ -143,13 +153,17 @@ public class DiscriminatorResolver {
 
 
     /**
-     * Resolves the element based on the given path from a discriminator
+     * Resolves the element based on the given path from a discriminator. Path segments are handled relative to
+     * {@code base}: {@code $this} is a no-op, {@code resolve()} follows a {@link Reference} via
+     * {@code resolutionContext} (a reference that does not resolve, e.g. because the target is outside the batch,
+     * yields {@code null} rather than throwing), and any other segment descends into a named child.
      *
-     * @param base          The base element from which the path starts
-     * @param discriminator The discriminator that contains the path
+     * @param base              The base element from which the path starts
+     * @param discriminator     The discriminator that contains the path
+     * @param resolutionContext lookup used to follow a {@code resolve()} step in the path
      * @return The resolved element if the path is valid, null otherwise
      */
-    private static Base resolveElementPath(Base base, ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent discriminator) throws FHIRException {
+    private static Base resolveElementPath(Base base, ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent discriminator, ReferenceResolutionContext resolutionContext) throws FHIRException {
         // Extract the path from the discriminator
 
         String path = discriminator.getPath();
@@ -167,6 +181,13 @@ public class DiscriminatorResolver {
             for (String part : parts) {
                 if (currentElement == null) {
                     return null;
+                }
+                if (part.equalsIgnoreCase("$this")) {
+                    continue;
+                }
+                if ("resolve()".equals(part)) {
+                    currentElement = resolveReference(currentElement, resolutionContext);
+                    continue;
                 }
                 // Resolve the next element based on the current part of the path
                 List<Base> nextElements = currentElement.listChildrenByName(part);
@@ -189,26 +210,50 @@ public class DiscriminatorResolver {
         return currentElement;
     }
 
+    /**
+     * Follows a {@code resolve()} path step: {@code currentElement} must be a {@link Reference} to a resource
+     * reachable through {@code resolutionContext}. Returns {@code null} for anything else (not a reference, an
+     * unparsable/absolute/contained reference, or a reference not present in the batch), the same "path did not
+     * resolve" outcome as any other unmatched path segment.
+     */
+    private static Base resolveReference(Base currentElement, ReferenceResolutionContext resolutionContext) {
+        if (!(currentElement instanceof Reference reference) || !reference.hasReference()) {
+            return null;
+        }
+        try {
+            ExtractionId id = ExtractionId.fromRelativeUrl(reference.getReference());
+            return resolutionContext.referenceResolver().apply(id).orElse(null);
+        } catch (IllegalArgumentException e) {
+            logger.trace("Could not parse reference '{}' for resolve()", reference.getReference());
+            return null;
+        }
+    }
+
 
     /**
      * Resolves the Type for a given slice
      *
-     * @param base     Element to be sliced
-     * @param slice    ElementDefinition of the slice
-     * @param snapshot Snapshot of the StructureDefinition
+     * @param base              Element to be sliced
+     * @param slice             ElementDefinition of the slice
+     * @param snapshot          Snapshot of the StructureDefinition
+     * @param resolutionContext lookups needed to evaluate a {@code resolve()} step in the discriminator path
      * @return true if type can be resolved and false if not
      */
-    private static Boolean resolveType(Base base, ElementDefinition slice, ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent discriminator, StructureDefinition.StructureDefinitionSnapshotComponent snapshot) {
+    private static Boolean resolveType(Base base, ElementDefinition slice, ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent discriminator, StructureDefinition.StructureDefinitionSnapshotComponent snapshot, ReferenceResolutionContext resolutionContext) {
+
+        // A reference-resolving path (e.g. "$this.resolve()") has no matching element in this snapshot to walk to
+        // via resolveSlicePath - the type constraint instead lives on the slice's own Reference.targetProfile.
+        if (isReferenceResolvingPath(discriminator.getPath())) {
+            return resolveReferenceResolvingType(base, slice, discriminator, resolutionContext);
+        }
 
         ElementDefinition elementContainingInfo = resolveSlicePath(slice, discriminator, snapshot);
 
-        // resolveSlicePath returns null for a non-"$this" path that doesn't resolve in the snapshot, e.g. a
-        // reference-resolving path such as "$this.resolve()".
         if (elementContainingInfo == null || elementContainingInfo.getType().isEmpty()) {
             return false; // No type information means the type cannot be resolved, so return false
         }
 
-        Base resolvedBase = resolveElementPath(base, discriminator);
+        Base resolvedBase = resolveElementPath(base, discriminator, resolutionContext);
 
         if (resolvedBase == null) {
             return false;
@@ -218,5 +263,59 @@ public class DiscriminatorResolver {
         return elementContainingInfo.getType().stream().anyMatch(x -> resolvedBase.fhirType().equalsIgnoreCase(x.getCode()));
     }
 
+    private static boolean isReferenceResolvingPath(String path) {
+        return path.endsWith("resolve()");
+    }
+
+    /**
+     * Resolves a {@code type} discriminator whose path resolves an external reference. The type constrained by each
+     * of the slice's {@code Reference.targetProfile} entries is looked up via {@code resolutionContext} (falling
+     * back to the canonical URL's trailing segment, which is the resource type for base HL7 StructureDefinition
+     * URLs such as {@code http://hl7.org/fhir/StructureDefinition/ImagingStudy}), and compared against the FHIR
+     * type of the resolved instance.
+     */
+    private static Boolean resolveReferenceResolvingType(Base base, ElementDefinition slice, ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent discriminator, ReferenceResolutionContext resolutionContext) {
+        Base resolvedBase = resolveElementPath(base, discriminator, resolutionContext);
+
+        if (resolvedBase == null) {
+            return false;
+        }
+
+        return slice.getType().stream()
+                .flatMap(type -> type.getTargetProfile().stream())
+                .map(CanonicalType::getValue)
+                .anyMatch(targetProfile -> resolvedBase.fhirType().equalsIgnoreCase(targetResourceType(targetProfile, resolutionContext)));
+    }
+
+    private static String targetResourceType(String targetProfileUrl, ReferenceResolutionContext resolutionContext) {
+        return resolutionContext.profileResolver().apply(targetProfileUrl)
+                .map(CompiledStructureDefinition::type)
+                .orElseGet(() -> targetProfileUrl.substring(targetProfileUrl.lastIndexOf('/') + 1));
+    }
+
+    /**
+     * Resolves a {@code profile} discriminator: the path is expected to resolve an external reference (e.g.
+     * {@code $this.resolve()} or {@code resolve()}), and the resolved instance must declare conformance, via its
+     * own {@code meta.profile}, to one of the slice's {@code Reference.targetProfile} entries. Version suffixes
+     * ({@code url|version}) are ignored on both sides.
+     */
+    private static Boolean resolveProfile(Base base, ElementDefinition slice, ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent discriminator, ReferenceResolutionContext resolutionContext) {
+        Base resolvedBase = resolveElementPath(base, discriminator, resolutionContext);
+
+        if (!(resolvedBase instanceof Resource resolvedResource)) {
+            return false;
+        }
+
+        Set<String> declaredProfiles = resolvedResource.getMeta().getProfile().stream()
+                .map(CanonicalType::getValue)
+                .map(ResourceUtils::stripVersion)
+                .collect(Collectors.toSet());
+
+        return slice.getType().stream()
+                .flatMap(type -> type.getTargetProfile().stream())
+                .map(CanonicalType::getValue)
+                .map(ResourceUtils::stripVersion)
+                .anyMatch(declaredProfiles::contains);
+    }
 
 }

--- a/src/main/java/de/medizininformatikinitiative/torch/util/Redaction.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/util/Redaction.java
@@ -6,6 +6,7 @@ import de.medizininformatikinitiative.torch.model.extraction.ExtractionId;
 import de.medizininformatikinitiative.torch.model.management.ElementContext;
 import de.medizininformatikinitiative.torch.model.management.ExtractionRedactionWrapper;
 import de.medizininformatikinitiative.torch.model.management.MultiElementContext;
+import de.medizininformatikinitiative.torch.model.management.ReferenceResolutionContext;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r4.model.Base;
 import org.hl7.fhir.r4.model.CanonicalType;
@@ -116,7 +117,8 @@ public class Redaction {
             throw new RedactionException("Trying to handle unknown profiles: " + wrapper.profiles());
         }
         meta.setProfile(resourceProfiles);
-        this.redact(resource, new MultiElementContext(String.valueOf(resource.getResourceType()), definitions), wrapper.references());
+        ReferenceResolutionContext resolutionContext = new ReferenceResolutionContext(wrapper.referenceResolver(), structureDefinitionHandler::getDefinition);
+        this.redact(resource, new MultiElementContext(String.valueOf(resource.getResourceType()), definitions, resolutionContext), wrapper.references());
         return resource;
     }
 
@@ -313,7 +315,7 @@ public class Redaction {
         // requirements the slice adds beyond the base type (e.g. a child required only within this named slice)
         // are also honored when masking the stub's own children.
         MultiElementContext sliceContext = new MultiElementContext(slice.getId(),
-                childContexts.contexts().stream().map(ElementContext::definition).toList());
+                childContexts.contexts().stream().map(ElementContext::definition).toList(), childContexts.resolutionContext());
         addDataAbsentReason(base, child, sliceTypes.getFirst(), sliceContext, references);
     }
 

--- a/src/main/java/de/medizininformatikinitiative/torch/util/Slicing.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/util/Slicing.java
@@ -1,5 +1,6 @@
 package de.medizininformatikinitiative.torch.util;
 
+import de.medizininformatikinitiative.torch.model.management.ReferenceResolutionContext;
 import org.hl7.fhir.r4.model.Base;
 import org.hl7.fhir.r4.model.CanonicalType;
 import org.hl7.fhir.r4.model.Element;
@@ -30,12 +31,13 @@ public class Slicing {
     /**
      * Checks if the given element is a sliced element and returns the sliced element otherwise null.
      *
-     * @param base       HAPI Base (Element) which should be checked
-     * @param elementId  Element ID of the above element.
-     * @param definition definition of the Resource to which the element belongs
+     * @param base              HAPI Base (Element) which should be checked
+     * @param elementId         Element ID of the above element.
+     * @param definition        definition of the Resource to which the element belongs
+     * @param resolutionContext lookups needed to evaluate a {@code resolve()} step in a discriminator path
      * @return Returns null if no slicing is found and an ElementDefinition for the slice otherwise
      */
-    public static Optional<ElementDefinition> resolveSlicing(Base base, String elementId, CompiledStructureDefinition definition) {
+    public static Optional<ElementDefinition> resolveSlicing(Base base, String elementId, CompiledStructureDefinition definition, ReferenceResolutionContext resolutionContext) {
         Optional<ElementDefinition> slicedElement = definition.elementDefinitionById(elementId);
 
         if (slicedElement.isEmpty()) {
@@ -74,7 +76,7 @@ public class Slicing {
                         }
                     }
                 }
-                if (!resolveDiscriminator(base, element, discriminator, definition.structureDefinition().getSnapshot())) {
+                if (!resolveDiscriminator(base, element, discriminator, definition.structureDefinition().getSnapshot(), resolutionContext)) {
                     foundSlice = false;
                     break; // Stop iterating if condition check fails
                 }

--- a/src/test/java/de/medizininformatikinitiative/torch/model/management/MultiElementContextTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/model/management/MultiElementContextTest.java
@@ -62,4 +62,11 @@ class MultiElementContextTest {
 
         assertThat(ctx.shouldRedactExtension(ext)).isTrue();
     }
+
+    @Test
+    void resolutionContext_returnsEmpty_whenNoContextsHeld() {
+        MultiElementContext ctx = new MultiElementContext(List.of());
+
+        assertThat(ctx.resolutionContext()).isSameAs(ReferenceResolutionContext.EMPTY);
+    }
 }

--- a/src/test/java/de/medizininformatikinitiative/torch/service/BatchCopierRedacterTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/service/BatchCopierRedacterTest.java
@@ -87,7 +87,7 @@ class BatchCopierRedacterTest {
         // but createWrapper must not run real logic
         doReturn(mock(ExtractionRedactionWrapper.class))
                 .when(transformer)
-                .createWrapper(any(), any(), any());
+                .createWrapper(any(), any(), any(), any());
     }
 
     @ParameterizedTest
@@ -150,10 +150,29 @@ class BatchCopierRedacterTest {
                     List.of(new AnnotatedAttribute("Patient.id", "Patient.id", false)), List.of());
             var info = new ResourceExtractionInfo(Set.of("G1"), Map.of());
 
-            var wrapper = real.createWrapper(patient, info, Map.of("G1", group));
+            var wrapper = real.createWrapper(patient, info, Map.of("G1", group), Map.of());
 
             assertThat(wrapper.resource()).isSameAs(patient);
             assertThat(wrapper.profiles()).containsExactly("http://profile/Patient");
+        }
+
+        /**
+         * The wrapper's {@code referenceResolver} must delegate to the {@code referenceLookup} snapshot passed
+         * into {@code createWrapper}, for both present and absent ids.
+         */
+        @Test
+        void referenceResolver_delegatesToProvidedLookup() throws RedactionException {
+            var patient = new Patient();
+            patient.setId("p1");
+            var info = new ResourceExtractionInfo(Set.of(), Map.of());
+            var otherPatient = new Patient();
+            otherPatient.setId("other");
+            var referenceLookup = Map.of(ExtractionId.fromRelativeUrl("Patient/other"), Optional.<Resource>of(otherPatient));
+
+            var wrapper = real.createWrapper(patient, info, Map.of(), referenceLookup);
+
+            assertThat(wrapper.referenceResolver().apply(ExtractionId.fromRelativeUrl("Patient/other"))).contains(otherPatient);
+            assertThat(wrapper.referenceResolver().apply(ExtractionId.fromRelativeUrl("Patient/missing"))).isEmpty();
         }
 
         @Test
@@ -162,7 +181,7 @@ class BatchCopierRedacterTest {
             patient.setId("p1");
             var info = new ResourceExtractionInfo(Set.of("unknown-group"), Map.of());
 
-            var wrapper = real.createWrapper(patient, info, Map.of());
+            var wrapper = real.createWrapper(patient, info, Map.of(), Map.of());
 
             assertThat(wrapper.resource()).isSameAs(patient);
             assertThat(wrapper.profiles()).isEmpty();
@@ -178,7 +197,7 @@ class BatchCopierRedacterTest {
                     List.of(new AnnotatedAttribute("Patient.name", "Patient.name", false)), List.of());
             var info = new ResourceExtractionInfo(Set.of("G1", "G2"), Map.of());
 
-            var wrapper = real.createWrapper(patient, info, Map.of("G1", g1, "G2", g2));
+            var wrapper = real.createWrapper(patient, info, Map.of("G1", g1, "G2", g2), Map.of());
 
             assertThat(wrapper.profiles()).containsExactlyInAnyOrder("http://profile/P1", "http://profile/P2");
         }

--- a/src/test/java/de/medizininformatikinitiative/torch/util/DiscriminatorResolverWithPathTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/util/DiscriminatorResolverWithPathTest.java
@@ -1,5 +1,7 @@
 package de.medizininformatikinitiative.torch.util;
 
+import de.medizininformatikinitiative.torch.model.extraction.ExtractionId;
+import de.medizininformatikinitiative.torch.model.management.ReferenceResolutionContext;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r4.model.*;
 import org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType;
@@ -7,6 +9,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -78,7 +82,7 @@ class DiscriminatorResolverWithPathTest {
         patientName.setFamily("Doe"); // Family name matches the fixed value
         basePatient.addName(patientName);
 
-        Boolean result = DiscriminatorResolver.resolveDiscriminator(basePatient, baseElement, discriminatorMock, snapshotMock);
+        Boolean result = DiscriminatorResolver.resolveDiscriminator(basePatient, baseElement, discriminatorMock, snapshotMock, ReferenceResolutionContext.EMPTY);
 
         assertTrue(result, "Should return true when discriminator type is 'value' and family name matches the fixed value");
     }
@@ -106,31 +110,87 @@ class DiscriminatorResolverWithPathTest {
         when(snapshotMock.getElementById("sliceId.slicePath.nonexistent.path")).thenReturn(null);
         Patient basePatient = new Patient();
 
-        Boolean result = DiscriminatorResolver.resolveDiscriminator(basePatient, slice, discriminatorMock, snapshotMock);
+        Boolean result = DiscriminatorResolver.resolveDiscriminator(basePatient, slice, discriminatorMock, snapshotMock, ReferenceResolutionContext.EMPTY);
 
         assertFalse(result, "Should return false when discriminator path does not exist in the snapshot");
     }
 
     /**
-     * Test when discriminator type is 'TYPE' and its path does not resolve to an element in the snapshot, as
-     * happens for reference-resolving paths like {@code $this.resolve()} used to slice by the referenced
-     * resource's type. Must return false rather than throw, like the 'VALUE'/'PATTERN' case above already does.
+     * Test when discriminator type is 'TYPE' with a reference-resolving path like {@code $this.resolve()}, and the
+     * referenced resource is not resolvable (e.g. not present in the batch). Must return false rather than throw.
      */
     @Test
-    void testResolveDiscriminator_TypeType_PathDoesNotExist() {
+    void testResolveDiscriminator_TypeType_ReferenceNotResolvable() {
         when(discriminatorMock.getType()).thenReturn(DiscriminatorType.TYPE);
         when(discriminatorMock.getPath()).thenReturn("$this.resolve()");
         ElementDefinition slice = new ElementDefinition();
         slice.setId("Observation.derivedFrom:attached-image");
-        when(snapshotMock.getElementById("Observation.derivedFrom:attached-image.$this.resolve()")).thenReturn(null);
 
         Reference reference = new Reference("DocumentReference/123");
 
-        Boolean result = DiscriminatorResolver.resolveDiscriminator(reference, slice, discriminatorMock, snapshotMock);
+        Boolean result = DiscriminatorResolver.resolveDiscriminator(reference, slice, discriminatorMock, snapshotMock, ReferenceResolutionContext.EMPTY);
 
-        assertFalse(result, "Should return false, not throw, when a type discriminator's path does not resolve in the snapshot");
+        assertFalse(result, "Should return false, not throw, when a type discriminator's reference does not resolve");
     }
 
+    /**
+     * Same shape as above, but its snapshot path (not a {@code resolve()} path) is missing instead - the case
+     * {@code testResolveDiscriminator_TypeType_ReferenceNotResolvable} covered before it was repurposed for the
+     * reference-resolving path.
+     */
+    @Test
+    void testResolveDiscriminator_TypeType_NonResolvePathDoesNotExist() {
+        when(discriminatorMock.getType()).thenReturn(DiscriminatorType.TYPE);
+        when(discriminatorMock.getPath()).thenReturn("unknownChild");
+        ElementDefinition slice = new ElementDefinition();
+        slice.setId("Patient");
+        when(snapshotMock.getElementById("Patient.unknownChild")).thenReturn(null);
+
+        Patient basePatient = new Patient();
+
+        Boolean result = DiscriminatorResolver.resolveDiscriminator(basePatient, slice, discriminatorMock, snapshotMock, ReferenceResolutionContext.EMPTY);
+
+        assertFalse(result, "Should return false when a non-resolve() type discriminator path is missing from the snapshot");
+    }
+
+    /**
+     * A {@code resolve()} path applied to a {@link Reference} with no {@code .reference} value set can never
+     * resolve, regardless of what the resolution context could otherwise provide.
+     */
+    @Test
+    void testResolveDiscriminator_TypeProfile_ReferenceWithoutReferenceValue() {
+        when(discriminatorMock.getType()).thenReturn(DiscriminatorType.PROFILE);
+        when(discriminatorMock.getPath()).thenReturn("$this.resolve()");
+        ElementDefinition slice = new ElementDefinition();
+        slice.setId("Observation.derivedFrom:variant");
+        slice.addType().setCode("Reference").addTargetProfile("https://www.medizininformatik-initiative.de/fhir/ext/modul-molgen/StructureDefinition/variante");
+
+        Reference reference = new Reference();
+        reference.setDisplay("no reference value set");
+
+        Boolean result = DiscriminatorResolver.resolveDiscriminator(reference, slice, discriminatorMock, snapshotMock, ReferenceResolutionContext.EMPTY);
+
+        assertFalse(result, "Should return false when the Reference has no reference value to resolve");
+    }
+
+    /**
+     * A {@code resolve()} path applied to a reference string that {@link ExtractionId#fromRelativeUrl} rejects
+     * (e.g. a {@code #contained} reference) must return false rather than throw.
+     */
+    @Test
+    void testResolveDiscriminator_TypeProfile_UnparsableReference() {
+        when(discriminatorMock.getType()).thenReturn(DiscriminatorType.PROFILE);
+        when(discriminatorMock.getPath()).thenReturn("$this.resolve()");
+        ElementDefinition slice = new ElementDefinition();
+        slice.setId("Observation.derivedFrom:variant");
+        slice.addType().setCode("Reference").addTargetProfile("https://www.medizininformatik-initiative.de/fhir/ext/modul-molgen/StructureDefinition/variante");
+
+        Reference reference = new Reference("#contained1");
+
+        Boolean result = DiscriminatorResolver.resolveDiscriminator(reference, slice, discriminatorMock, snapshotMock, ReferenceResolutionContext.EMPTY);
+
+        assertFalse(result, "Should return false, not throw, when the reference cannot be parsed into an ExtractionId");
+    }
 
     /**
      * Test when discriminator type is 'TYPE' and its path resolves to a child of the sliced element (e.g.
@@ -151,7 +211,7 @@ class DiscriminatorResolverWithPathTest {
         Bundle.BundleEntryComponent entry = new Bundle.BundleEntryComponent();
         entry.setResource(new Composition());
 
-        Boolean result = DiscriminatorResolver.resolveDiscriminator(entry, slice, discriminatorMock, snapshotMock);
+        Boolean result = DiscriminatorResolver.resolveDiscriminator(entry, slice, discriminatorMock, snapshotMock, ReferenceResolutionContext.EMPTY);
 
         assertTrue(result, "Should match against the resolved child at the discriminator path, not the outer sliced element itself");
     }
@@ -173,7 +233,7 @@ class DiscriminatorResolverWithPathTest {
         Bundle.BundleEntryComponent entry = new Bundle.BundleEntryComponent();
         entry.setResource(new Patient());
 
-        Boolean result = DiscriminatorResolver.resolveDiscriminator(entry, slice, discriminatorMock, snapshotMock);
+        Boolean result = DiscriminatorResolver.resolveDiscriminator(entry, slice, discriminatorMock, snapshotMock, ReferenceResolutionContext.EMPTY);
 
         assertFalse(result, "Should not match when the resolved child's type differs from the slice's declared type");
     }
@@ -196,7 +256,7 @@ class DiscriminatorResolverWithPathTest {
 
         Bundle.BundleEntryComponent entry = new Bundle.BundleEntryComponent();
 
-        Boolean result = DiscriminatorResolver.resolveDiscriminator(entry, slice, discriminatorMock, snapshotMock);
+        Boolean result = DiscriminatorResolver.resolveDiscriminator(entry, slice, discriminatorMock, snapshotMock, ReferenceResolutionContext.EMPTY);
 
         assertFalse(result, "Should return false, not throw, when the discriminator path does not resolve on the actual base instance");
     }
@@ -226,7 +286,7 @@ class DiscriminatorResolverWithPathTest {
         code.addCoding(new Coding("urn:iso:std:iso:11073:10101", "150017", "Systolic blood pressure"));
         component.setCode(code);
 
-        Boolean result = DiscriminatorResolver.resolveDiscriminator(component, slice, discriminatorMock, snapshotMock);
+        Boolean result = DiscriminatorResolver.resolveDiscriminator(component, slice, discriminatorMock, snapshotMock, ReferenceResolutionContext.EMPTY);
 
         assertTrue(result, "Should match when any coding in the array matches the pattern, not just the first");
     }
@@ -249,8 +309,149 @@ class DiscriminatorResolverWithPathTest {
         Extension parentExtension = new Extension("name", new Extension("code", new StringType("someValue")));
         basePatient.addExtension(parentExtension);
 
-        Boolean result = DiscriminatorResolver.resolveDiscriminator(basePatient, slice, discriminatorMock, snapshotMock);
+        Boolean result = DiscriminatorResolver.resolveDiscriminator(basePatient, slice, discriminatorMock, snapshotMock, ReferenceResolutionContext.EMPTY);
 
         assertFalse(result, "Should return false when discriminator type is 'value' but no fixed value is set at the specified path");
+    }
+
+    /**
+     * Reproduces #1173 (base-URL case): a 'TYPE' discriminator at {@code $this.resolve()}, as used e.g. by
+     * {@code Observation.derivedFrom:dicom-image} in mii-pr-patho-finding, whose {@code targetProfile} is a base
+     * HL7 canonical URL not loaded as an ontology profile - the resource type falls back to the URL's own
+     * trailing segment.
+     */
+    @Test
+    void testResolveDiscriminator_TypeType_ResolvesReferenceAgainstBaseTargetProfile() {
+        when(discriminatorMock.getType()).thenReturn(DiscriminatorType.TYPE);
+        when(discriminatorMock.getPath()).thenReturn("$this.resolve()");
+
+        ElementDefinition slice = new ElementDefinition();
+        slice.setId("Observation.derivedFrom:dicom-image");
+        slice.addType().setCode("Reference").addTargetProfile("http://hl7.org/fhir/StructureDefinition/ImagingStudy");
+
+        Reference reference = new Reference("ImagingStudy/img1");
+        ImagingStudy imagingStudy = new ImagingStudy();
+        imagingStudy.setId("img1");
+
+        ReferenceResolutionContext resolutionContext = new ReferenceResolutionContext(
+                id -> id.equals(ExtractionId.fromRelativeUrl("ImagingStudy/img1")) ? Optional.of(imagingStudy) : Optional.empty(),
+                url -> Optional.empty());
+
+        Boolean result = DiscriminatorResolver.resolveDiscriminator(reference, slice, discriminatorMock, snapshotMock, resolutionContext);
+
+        assertTrue(result, "Should match by resource type when the target profile is a base HL7 canonical URL");
+    }
+
+    /**
+     * Reproduces #1173 (custom-profile case): same shape, but {@code targetProfile} is a custom MII profile whose
+     * own base resource type ("Media", as for mii-pr-patho-attached-image) differs from its URL's trailing
+     * segment ("mii-pr-patho-attached-image") - the type must come from the resolved profile, not the URL.
+     */
+    @Test
+    void testResolveDiscriminator_TypeType_ResolvesReferenceAgainstCustomTargetProfile() {
+        when(discriminatorMock.getType()).thenReturn(DiscriminatorType.TYPE);
+        when(discriminatorMock.getPath()).thenReturn("$this.resolve()");
+
+        String profileUrl = "https://www.medizininformatik-initiative.de/fhir/ext/modul-patho/StructureDefinition/mii-pr-patho-attached-image";
+        ElementDefinition slice = new ElementDefinition();
+        slice.setId("Observation.derivedFrom:attached-image");
+        slice.addType().setCode("Reference").addTargetProfile(profileUrl);
+
+        Reference reference = new Reference("Media/media1");
+        Media media = new Media();
+        media.setId("media1");
+
+        StructureDefinition attachedImageProfile = new StructureDefinition();
+        attachedImageProfile.setUrl(profileUrl);
+        attachedImageProfile.setType("Media");
+        CompiledStructureDefinition compiled = CompiledStructureDefinition.fromStructureDefinition(attachedImageProfile);
+
+        ReferenceResolutionContext resolutionContext = new ReferenceResolutionContext(
+                id -> id.equals(ExtractionId.fromRelativeUrl("Media/media1")) ? Optional.of(media) : Optional.empty(),
+                url -> url.equals(profileUrl) ? Optional.of(compiled) : Optional.empty());
+
+        Boolean result = DiscriminatorResolver.resolveDiscriminator(reference, slice, discriminatorMock, snapshotMock, resolutionContext);
+
+        assertTrue(result, "Should match by the target profile's own declared base type, not its URL's trailing segment");
+    }
+
+    /**
+     * Same shape as above, but the resolved resource's type does not match any of the slice's target profiles.
+     */
+    @Test
+    void testResolveDiscriminator_TypeType_ResolvedReferenceTypeMismatch() {
+        when(discriminatorMock.getType()).thenReturn(DiscriminatorType.TYPE);
+        when(discriminatorMock.getPath()).thenReturn("$this.resolve()");
+
+        ElementDefinition slice = new ElementDefinition();
+        slice.setId("Observation.derivedFrom:dicom-image");
+        slice.addType().setCode("Reference").addTargetProfile("http://hl7.org/fhir/StructureDefinition/ImagingStudy");
+
+        Reference reference = new Reference("Patient/p1");
+        Patient patient = new Patient();
+        patient.setId("p1");
+
+        ReferenceResolutionContext resolutionContext = new ReferenceResolutionContext(
+                id -> id.equals(ExtractionId.fromRelativeUrl("Patient/p1")) ? Optional.of(patient) : Optional.empty(),
+                url -> Optional.empty());
+
+        Boolean result = DiscriminatorResolver.resolveDiscriminator(reference, slice, discriminatorMock, snapshotMock, resolutionContext);
+
+        assertFalse(result, "Should not match when the resolved resource's type differs from every target profile's type");
+    }
+
+    /**
+     * Reproduces #1173's 'PROFILE' case, as used e.g. by {@code Observation.derivedFrom:variant} in
+     * mii-pr-molgen-diagnostische-implikation: the resolved resource must declare, in its own {@code meta.profile},
+     * conformance to one of the slice's target profiles.
+     */
+    @Test
+    void testResolveDiscriminator_TypeProfile_ResolvedReferenceDeclaresMatchingProfile() {
+        when(discriminatorMock.getType()).thenReturn(DiscriminatorType.PROFILE);
+        when(discriminatorMock.getPath()).thenReturn("resolve()");
+
+        String profileUrl = "https://www.medizininformatik-initiative.de/fhir/ext/modul-molgen/StructureDefinition/variante";
+        ElementDefinition slice = new ElementDefinition();
+        slice.setId("Observation.derivedFrom:variant");
+        slice.addType().setCode("Reference").addTargetProfile(profileUrl);
+
+        Reference reference = new Reference("Observation/variant1");
+        Observation variant = new Observation();
+        variant.setId("variant1");
+        variant.getMeta().addProfile(profileUrl + "|1.0.0");
+
+        ReferenceResolutionContext resolutionContext = new ReferenceResolutionContext(
+                id -> id.equals(ExtractionId.fromRelativeUrl("Observation/variant1")) ? Optional.of(variant) : Optional.empty(),
+                url -> Optional.empty());
+
+        Boolean result = DiscriminatorResolver.resolveDiscriminator(reference, slice, discriminatorMock, snapshotMock, resolutionContext);
+
+        assertTrue(result, "Should match, ignoring the version suffix, when the resolved resource declares the target profile");
+    }
+
+    /**
+     * Same shape as above, but the resolved resource declares a different profile.
+     */
+    @Test
+    void testResolveDiscriminator_TypeProfile_ResolvedReferenceDeclaresDifferentProfile() {
+        when(discriminatorMock.getType()).thenReturn(DiscriminatorType.PROFILE);
+        when(discriminatorMock.getPath()).thenReturn("resolve()");
+
+        ElementDefinition slice = new ElementDefinition();
+        slice.setId("Observation.derivedFrom:variant");
+        slice.addType().setCode("Reference").addTargetProfile("https://www.medizininformatik-initiative.de/fhir/ext/modul-molgen/StructureDefinition/variante");
+
+        Reference reference = new Reference("Observation/other1");
+        Observation other = new Observation();
+        other.setId("other1");
+        other.getMeta().addProfile("https://www.medizininformatik-initiative.de/fhir/ext/modul-molgen/StructureDefinition/haplotyp");
+
+        ReferenceResolutionContext resolutionContext = new ReferenceResolutionContext(
+                id -> id.equals(ExtractionId.fromRelativeUrl("Observation/other1")) ? Optional.of(other) : Optional.empty(),
+                url -> Optional.empty());
+
+        Boolean result = DiscriminatorResolver.resolveDiscriminator(reference, slice, discriminatorMock, snapshotMock, resolutionContext);
+
+        assertFalse(result, "Should not match when the resolved resource declares a different profile");
     }
 }

--- a/src/test/java/de/medizininformatikinitiative/torch/util/DiscriminatorResolverWithoutPathTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/util/DiscriminatorResolverWithoutPathTest.java
@@ -1,5 +1,6 @@
 package de.medizininformatikinitiative.torch.util;
 
+import de.medizininformatikinitiative.torch.model.management.ReferenceResolutionContext;
 import org.hl7.fhir.r4.model.*;
 import org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType;
 import org.junit.jupiter.api.Test;
@@ -74,7 +75,7 @@ class DiscriminatorResolverWithoutPathTest {
         // No need to mock baseElement's fhirType; real instance returns "string"
 
         // Act
-        Boolean result = DiscriminatorResolver.resolveDiscriminator(baseElement, slice, discriminatorMock, snapshotMock);
+        Boolean result = DiscriminatorResolver.resolveDiscriminator(baseElement, slice, discriminatorMock, snapshotMock, ReferenceResolutionContext.EMPTY);
 
         // Assert
         assertTrue(result, "Should return true when discriminator type is 'value' and value matches");
@@ -104,7 +105,7 @@ class DiscriminatorResolverWithoutPathTest {
         // No need to mock baseElement's fhirType; real instance returns "string"
 
         // Act
-        Boolean result = DiscriminatorResolver.resolveDiscriminator(baseElement, slice, discriminatorMock, snapshotMock);
+        Boolean result = DiscriminatorResolver.resolveDiscriminator(baseElement, slice, discriminatorMock, snapshotMock, ReferenceResolutionContext.EMPTY);
 
         // Assert
         assertFalse(result, "Should return false when discriminator type is 'value' but value does not match");
@@ -133,7 +134,7 @@ class DiscriminatorResolverWithoutPathTest {
         // No need to mock baseElement's fhirType; real instance returns "string"
 
         // Act
-        Boolean result = DiscriminatorResolver.resolveDiscriminator(baseElement, slice, discriminatorMock, snapshotMock);
+        Boolean result = DiscriminatorResolver.resolveDiscriminator(baseElement, slice, discriminatorMock, snapshotMock, ReferenceResolutionContext.EMPTY);
 
         // Assert
         assertTrue(result, "Should return true when discriminator type is 'type' and types match");
@@ -161,7 +162,7 @@ class DiscriminatorResolverWithoutPathTest {
         // No need to mock baseElement's fhirType; real instance returns "integer"
 
         // Act
-        Boolean result = DiscriminatorResolver.resolveDiscriminator(baseElement, slice, discriminatorMock, snapshotMock);
+        Boolean result = DiscriminatorResolver.resolveDiscriminator(baseElement, slice, discriminatorMock, snapshotMock, ReferenceResolutionContext.EMPTY);
 
         // Assert
         assertFalse(result, "Should return false when discriminator type is 'type' but types do not match");
@@ -185,20 +186,21 @@ class DiscriminatorResolverWithoutPathTest {
         StringType baseElement = new StringType("anyValue");
 
         // Act
-        Boolean result = DiscriminatorResolver.resolveDiscriminator(baseElement, slice, discriminatorMock, snapshotMock);
+        Boolean result = DiscriminatorResolver.resolveDiscriminator(baseElement, slice, discriminatorMock, snapshotMock, ReferenceResolutionContext.EMPTY);
 
         // Assert
         assertFalse(result, "Should return false when discriminator type is 'exists'");
     }
 
     /**
-     * Test when discriminator type is 'PROFILE'.
+     * Test when discriminator type is 'PROFILE' and the path (as always in practice, per FHIR spec) resolves an
+     * external reference. Here the base element isn't even a {@link Reference}, so it can never resolve.
      */
     @Test
     void testResolveDiscriminator_TypeProfile() {
         // Arrange
         when(discriminatorMock.getType()).thenReturn(DiscriminatorType.PROFILE);
-        // The path can be anything since 'PROFILE' should return false immediately
+        when(discriminatorMock.getPath()).thenReturn("$this.resolve()");
 
         // Create a real ElementDefinition instance for the slice
         ElementDefinition slice = new ElementDefinition();
@@ -206,11 +208,11 @@ class DiscriminatorResolverWithoutPathTest {
         // 'PROFILE' does not utilize fixed or type, so no need to set them
 
 
-        // Create a base element (value is irrelevant)
+        // Create a base element (not a Reference, so resolve() can never yield anything)
         StringType baseElement = new StringType("anyValue");
 
         // Act
-        Boolean result = DiscriminatorResolver.resolveDiscriminator(baseElement, slice, discriminatorMock, snapshotMock);
+        Boolean result = DiscriminatorResolver.resolveDiscriminator(baseElement, slice, discriminatorMock, snapshotMock, ReferenceResolutionContext.EMPTY);
 
         // Assert
         assertFalse(result, "Should return false when discriminator type is 'profile'");
@@ -245,7 +247,7 @@ class DiscriminatorResolverWithoutPathTest {
         StringType baseElement = new StringType("anyValue");
 
         // Act
-        Boolean result = DiscriminatorResolver.resolveDiscriminator(baseElement, slice, discriminatorMock, snapshotMock);
+        Boolean result = DiscriminatorResolver.resolveDiscriminator(baseElement, slice, discriminatorMock, snapshotMock, ReferenceResolutionContext.EMPTY);
 
         // Assert
         assertFalse(result, "Should return false for unknown discriminator type");

--- a/src/test/java/de/medizininformatikinitiative/torch/util/RedactionTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/util/RedactionTest.java
@@ -16,12 +16,15 @@ import org.hl7.fhir.r4.model.DomainResource;
 import org.hl7.fhir.r4.model.Encounter;
 import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.Identifier;
+import org.hl7.fhir.r4.model.ImagingStudy;
+import org.hl7.fhir.r4.model.Media;
 import org.hl7.fhir.r4.model.Medication;
 import org.hl7.fhir.r4.model.Meta;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Quantity;
 import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.StringType;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -32,6 +35,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static de.medizininformatikinitiative.torch.util.FhirUtil.createAbsentReasonExtension;
@@ -52,6 +56,8 @@ public class RedactionTest {
     public static final String VITALSTATUS = "https://www.medizininformatik-initiative.de/fhir/core/modul-person/StructureDefinition/Vitalstatus";
     public static final String ENCOUNTER = "https://www.medizininformatik-initiative.de/fhir/core/modul-fall/StructureDefinition/KontaktGesundheitseinrichtung";
     public static final String BLOOD_PRESSURE = "https://gematik.de/fhir/isik/StructureDefinition/ISiKBlutdruckSystemischArteriell";
+    public static final String PATHO_FINDING = "https://www.medizininformatik-initiative.de/fhir/ext/modul-patho/StructureDefinition/mii-pr-patho-finding";
+    public static final String ATTACHED_IMAGE = "https://www.medizininformatik-initiative.de/fhir/ext/modul-patho/StructureDefinition/mii-pr-patho-attached-image";
 
     private final IntegrationTestSetup integrationTestSetup;
 
@@ -115,6 +121,48 @@ public class RedactionTest {
                 .contains(tuple("http://snomed.info/sct", "271650006"));
         assertThat(tgt.getComponent().get(1).getValueQuantity().getValue()).isEqualByComparingTo("76");
         assertThat(tgt.getComponent().get(1).getValueQuantity().getCode()).isEqualTo("mm[Hg]");
+    }
+
+    /**
+     * Reproduces #1173: {@code Observation.derivedFrom} in mii-pr-patho-finding is sliced by a 'TYPE' discriminator
+     * at path {@code $this.resolve()} into {@code dicom-image} (target profile is the base HL7 canonical URL for
+     * {@code ImagingStudy}) and {@code attached-image} (target profile is the custom MII profile
+     * mii-pr-patho-attached-image, whose own declared base type is {@code Media}). Before the fix, both slices'
+     * discriminator always evaluated to false, so every value was wiped by slicing regardless of the referenced
+     * resource's actual type.
+     */
+    @Test
+    void referenceResolvingTypeDiscriminatorMatchesBothBaseAndCustomTargetProfiles() throws RedactionException {
+        Observation observation = new Observation();
+        observation.setId("finding1");
+        observation.getMeta().addProfile(PATHO_FINDING);
+        observation.addDerivedFrom(new Reference("ImagingStudy/img1"));
+        observation.addDerivedFrom(new Reference("Media/media1"));
+
+        ImagingStudy imagingStudy = new ImagingStudy();
+        imagingStudy.setId("img1");
+
+        Media media = new Media();
+        media.setId("media1");
+        media.getMeta().addProfile(ATTACHED_IMAGE);
+
+        Map<ExtractionId, Optional<Resource>> resolvedReferences = Map.of(
+                ExtractionId.fromRelativeUrl("ImagingStudy/img1"), Optional.of(imagingStudy),
+                ExtractionId.fromRelativeUrl("Media/media1"), Optional.of(media)
+        );
+
+        ExtractionRedactionWrapper wrapper = new ExtractionRedactionWrapper(
+                observation,
+                Set.of(PATHO_FINDING),
+                Map.of("Observation.derivedFrom", ExtractionId.of("ImagingStudy/img1", "Media/media1")),
+                new CopyTreeNode("dummy"),
+                id -> resolvedReferences.getOrDefault(id, Optional.empty())
+        );
+
+        Observation tgt = (Observation) integrationTestSetup.redaction().redact(wrapper);
+
+        assertThat(tgt.getDerivedFrom()).extracting(Reference::getReference)
+                .containsExactlyInAnyOrder("ImagingStudy/img1", "Media/media1");
     }
 
     /**

--- a/src/test/java/de/medizininformatikinitiative/torch/util/SlicingTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/util/SlicingTest.java
@@ -1,6 +1,7 @@
 package de.medizininformatikinitiative.torch.util;
 
 import ca.uhn.fhir.context.FhirContext;
+import de.medizininformatikinitiative.torch.model.management.ReferenceResolutionContext;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r4.model.Base;
 import org.hl7.fhir.r4.model.Bundle;
@@ -33,7 +34,7 @@ class SlicingTest {
         snapshot.addElement(elementDefinition);
         Base base = Mockito.mock(Base.class);
 
-        Optional<ElementDefinition> result = Slicing.resolveSlicing(base, "Patient.contact", CompiledStructureDefinition.fromStructureDefinition(structureDefinition));
+        Optional<ElementDefinition> result = Slicing.resolveSlicing(base, "Patient.contact", CompiledStructureDefinition.fromStructureDefinition(structureDefinition), ReferenceResolutionContext.EMPTY);
 
         assertThat(result).isEmpty();
     }


### PR DESCRIPTION
## Summary
- `DiscriminatorResolver` can now evaluate `type` and `profile` discriminators whose path resolves an external reference (`$this.resolve()` / `resolve()`), via a new `ReferenceResolutionContext` threaded through `ElementContext`/`MultiElementContext`/`Slicing` and populated from the batch's already-resolved resource cache and the loaded ontology profiles.
- `type` discriminators compare the resolved resource's actual FHIR type against each target profile's declared base type (looked up via the ontology handler, falling back to the profile URL's trailing segment for bare base-HL7 canonical URLs) — verified against real MII ontology data, since comparing against `type.code` (as before) can never work for these paths (`code` is always `"Reference"`).
- `profile` discriminators (previously unimplemented, always `false`) compare the resolved resource's `meta.profile` against the slice's target profiles.
- `BatchCopierRedacter` snapshots the batch's resolved-resource cache once before its `parallelStream()` redaction pass, so discriminator `resolve()` lookups can't race concurrent in-place redaction of the same batch.

## Out of scope
- Absolute (non-`$this`-relative) discriminator paths such as `Composition.section.entry.resolve()` — tracked separately in #1187.
- Full `value`/`pattern` + `resolve()` support, which needs cross-profile snapshot pattern lookup — part of #1180's broader rework.

## Test plan
- [x] New unit tests in `DiscriminatorResolverWithPathTest`/`DiscriminatorResolverWithoutPathTest` covering both branches of the `type` two-tier lookup (base-URL fallback, custom-profile lookup) and `profile` match/mismatch.
- [x] New `RedactionTest` exercising the real `mii-pr-patho-finding`/`mii-pr-patho-attached-image` ontology profiles end-to-end, proving previously-always-wiped `Observation.derivedFrom` slices now survive redaction.
- [x] Full unit test suite run locally: 0 failures (pre-existing container-dependent test errors unrelated to this change).

Closes #1173