### PR TITLE
Add Encounter Shift Toggle In Consent

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -224,6 +224,16 @@ Flag indicating whether to enable Clinical Quality Language (CQL) for processing
 
 ---
 
+#### `TORCH_ENABLE_ENCOUNTER_SHIFT` <Badge type="warning" text="Since 1.0.1"/>
+
+Flag indicating whether data-period consent provisions are shifted to the start of an earlier overlapping
+Encounter (see [Encounter Adjustment](./implementation/consent.md#encounter-adjustment)). When disabled, consent
+provisions are used as fetched and no Encounter search is performed.
+
+**Default:** `true`
+
+---
+
 ---
 
 #### `TORCH_OUTPUT_FILE_SERVER_URL` <Badge type="warning" text="Since 1.0.0-alpha"/>

--- a/docs/implementation/consent.md
+++ b/docs/implementation/consent.md
@@ -86,7 +86,9 @@ Before any data extraction:
 5. **Adjust by Encounter** — for data-period codes (non-gate codes, i.e. `.6`), the start of each permitted provision
    is shifted to the start of the earliest overlapping Encounter if that Encounter start is earlier. Encounters
    without both a start and end date are ignored i.e. an open-ended (ongoing) encounter cannot anchor the shift. Gate
-   codes (`.8`) are never encounter-adjusted by design.
+   codes (`.8`) are never encounter-adjusted by design. This step can be turned off entirely via
+   `TORCH_ENABLE_ENCOUNTER_SHIFT` (default `true`); when disabled, no Encounter search is performed and provisions
+   are used as fetched.
 6. **Apply retrospective modifiers** — only for modifier codes (`.45`/`.46`) explicitly requested in the CRTDL
    cohort definition (see step 4). Within each Consent resource independently: if a permitted `.6` provision
    overlaps in time with a permitted retro modifier provision **in the same resource**, the `.6`

--- a/src/main/java/de/medizininformatikinitiative/torch/consent/ConsentHandler.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/consent/ConsentHandler.java
@@ -5,6 +5,7 @@ import de.medizininformatikinitiative.torch.model.consent.PatientBatchWithConsen
 import de.medizininformatikinitiative.torch.model.management.PatientBatch;
 import de.medizininformatikinitiative.torch.model.management.TermCode;
 import de.medizininformatikinitiative.torch.service.DataStore;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
@@ -27,20 +28,25 @@ public class ConsentHandler {
     private final ConsentAdjuster consentAdjuster;
     private final ConsentCalculator consentCalculator;
     private final ConsentCodeConfig consentCodeConfig;
+    private final boolean enableEncounterShift;
 
     /**
      * Constructs a new {@code ConsentHandler} with the specified dependencies.
      *
-     * @param consentFetcher    the {@link ConsentFetcher} for fetching and building consent provisions
-     * @param consentAdjuster   the {@link ConsentAdjuster} for adjusting consent periods by encounter periods
+     * @param consentFetcher the {@link ConsentFetcher} for fetching and building consent provisions
+     * @param consentAdjuster the {@link ConsentAdjuster} for adjusting consent periods by encounter periods
      * @param consentCalculator the {@link ConsentCalculator} for calculating effective consent periods
      * @param consentCodeConfig the {@link ConsentCodeConfig} describing supported codes and their roles
+     * @param enableEncounterShift whether data-period provisions are shifted to overlapping encounter starts
+     *                             ({@code torch.enableEncounterShift})
      */
-    public ConsentHandler(ConsentFetcher consentFetcher, ConsentAdjuster consentAdjuster, ConsentCalculator consentCalculator, ConsentCodeConfig consentCodeConfig) {
+    public ConsentHandler(ConsentFetcher consentFetcher, ConsentAdjuster consentAdjuster, ConsentCalculator consentCalculator, ConsentCodeConfig consentCodeConfig,
+                           @Value("${torch.enableEncounterShift}") boolean enableEncounterShift) {
         this.consentFetcher = requireNonNull(consentFetcher);
         this.consentAdjuster = requireNonNull(consentAdjuster);
         this.consentCalculator = requireNonNull(consentCalculator);
         this.consentCodeConfig = requireNonNull(consentCodeConfig);
+        this.enableEncounterShift = enableEncounterShift;
     }
 
     /**
@@ -49,7 +55,8 @@ public class ConsentHandler {
      * This method performs the following steps in a reactive pipeline:
      * <ol>
      *     <li>Fetches consent provisions from a FHIR server for the given {@code consentCodes} and patient batch.</li>
-     *     <li>Adjusts the fetched consent periods based on patient encounters.</li>
+     *     <li>Adjusts the fetched consent periods based on patient encounters, unless disabled via
+     *     {@code torch.enableEncounterShift}.</li>
      *     <li>Calculates the effective consent periods per patient.</li>
      *     <li>Filters the batch to include only patients with valid consent periods.</li>
      * </ol>
@@ -68,7 +75,9 @@ public class ConsentHandler {
 
         return consentFetcher.fetchConsentInfo(codesToFetch, batch)
                 .flatMap(consentProvisions ->
-                        consentAdjuster.fetchEncounterAndAdjustByEncounter(batch, consentProvisions, encounterAdjustCodes)
+                        enableEncounterShift
+                                ? consentAdjuster.fetchEncounterAndAdjustByEncounter(batch, consentProvisions, encounterAdjustCodes)
+                                : Mono.just(consentProvisions)
                 )
                 .map(consentProvisions -> consentCalculator.calculateConsent(prospectiveCodes, consentProvisions))
                 .flatMap(consentPeriodsMap ->

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,6 +43,7 @@ torch:
   useCql: true
   bufferSize: 100
   disableConsentCalculation: ${DISABLE_CONSENT_CALCULATION:false}
+  enableEncounterShift: true
   output:
     file:
       server:

--- a/src/test/java/de/medizininformatikinitiative/torch/consent/ConsentHandlerTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/consent/ConsentHandlerTest.java
@@ -2,19 +2,28 @@ package de.medizininformatikinitiative.torch.consent;
 
 import de.medizininformatikinitiative.torch.exceptions.ConsentViolatedException;
 import de.medizininformatikinitiative.torch.model.consent.ConsentCodeConfig;
+import de.medizininformatikinitiative.torch.model.consent.ConsentProvisions;
+import de.medizininformatikinitiative.torch.model.consent.NonContinuousPeriod;
+import de.medizininformatikinitiative.torch.model.consent.Period;
 import de.medizininformatikinitiative.torch.model.management.PatientBatch;
 import de.medizininformatikinitiative.torch.model.management.TermCode;
+import org.hl7.fhir.r4.model.DateTimeType;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -39,8 +48,12 @@ public class ConsentHandlerTest {
     @Mock
     ConsentCodeConfig consentCodeConfig;
 
-    @InjectMocks
     ConsentHandler consentHandler;
+
+    @BeforeEach
+    void setUp() {
+        consentHandler = new ConsentHandler(consentFetcher, consentAdjuster, consentCalculator, consentCodeConfig, true);
+    }
 
     @Test
     void failsOnNoPatientMatchesConsentKeyBuildingConsent() {
@@ -72,6 +85,53 @@ public class ConsentHandlerTest {
                         .isInstanceOf(ConsentViolatedException.class)
                         .hasMessageContaining("No valid consentPeriods found for any patients in batch"))
                 .verify();
+    }
+
+    private Map<String, List<ConsentProvisions>> provisionsByPatient() {
+        return Map.of(PATIENT_ID, List.of(new ConsentProvisions(PATIENT_ID, new DateTimeType(), List.of())));
+    }
+
+    private Map<String, NonContinuousPeriod> consentPeriodsByPatient() {
+        return Map.of(PATIENT_ID, NonContinuousPeriod.of(new Period(LocalDate.of(2020, 1, 1), LocalDate.of(2030, 1, 1))));
+    }
+
+    @Test
+    void encounterShiftEnabledInvokesConsentAdjuster() {
+        var codes = CODES;
+        var fetchedProvisions = provisionsByPatient();
+        var adjustedProvisions = provisionsByPatient();
+
+        when(consentCodeConfig.extractRequestedProspectiveCodes(codes)).thenReturn(codes);
+        when(consentCodeConfig.withRetroModifiers(codes, codes)).thenReturn(codes);
+        when(consentCodeConfig.nonGateCodes(codes)).thenReturn(codes);
+        when(consentFetcher.fetchConsentInfo(codes, BATCH)).thenReturn(Mono.just(fetchedProvisions));
+        when(consentAdjuster.fetchEncounterAndAdjustByEncounter(BATCH, fetchedProvisions, codes)).thenReturn(Mono.just(adjustedProvisions));
+        when(consentCalculator.calculateConsent(codes, adjustedProvisions)).thenReturn(consentPeriodsByPatient());
+
+        StepVerifier.create(consentHandler.fetchAndBuildConsentInfo(codes, BATCH))
+                .assertNext(result -> assertThat(result.patientIds()).containsExactly(PATIENT_ID))
+                .verifyComplete();
+
+        verify(consentAdjuster).fetchEncounterAndAdjustByEncounter(BATCH, fetchedProvisions, codes);
+    }
+
+    @Test
+    void encounterShiftDisabledSkipsConsentAdjuster() {
+        var codes = CODES;
+        var fetchedProvisions = provisionsByPatient();
+        var handler = new ConsentHandler(consentFetcher, consentAdjuster, consentCalculator, consentCodeConfig, false);
+
+        when(consentCodeConfig.extractRequestedProspectiveCodes(codes)).thenReturn(codes);
+        when(consentCodeConfig.withRetroModifiers(codes, codes)).thenReturn(codes);
+        when(consentCodeConfig.nonGateCodes(codes)).thenReturn(codes);
+        when(consentFetcher.fetchConsentInfo(codes, BATCH)).thenReturn(Mono.just(fetchedProvisions));
+        when(consentCalculator.calculateConsent(codes, fetchedProvisions)).thenReturn(consentPeriodsByPatient());
+
+        StepVerifier.create(handler.fetchAndBuildConsentInfo(codes, BATCH))
+                .assertNext(result -> assertThat(result.patientIds()).containsExactly(PATIENT_ID))
+                .verifyComplete();
+
+        verifyNoInteractions(consentAdjuster);
     }
 
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -33,6 +33,7 @@ torch:
   conceptTreeFile: ontology/mapping_tree.json
   dseMappingTreeFile: ontology/dse_mapping_tree.json
   useCql: true
+  enableEncounterShift: true
   bufferSize: 100
   output:
     file:


### PR DESCRIPTION
## Summary
- Add `torch.enableEncounterShift` config flag (default `true`) to allow turning off encounter-based shifting of data-period consent provisions.
- When disabled, `ConsentHandler` skips `ConsentAdjuster.fetchEncounterAndAdjustByEncounter` entirely — no `Encounter` FHIR search is performed and provisions are used as fetched.
- Documented as `TORCH_ENABLE_ENCOUNTER_SHIFT` in `docs/configuration.md` and referenced in the consent pipeline docs (step 5).

## Test plan
- [x] `mvn -Dtest=ConsentHandlerTest test` — new `encounterShiftEnabledInvokesConsentAdjuster` / `encounterShiftDisabledSkipsConsentAdjuster` tests pass
- [x] `mvn -P download-ontology test-compile` — full compile clean
- [ ] `ConsentHandlerIT` (Testcontainers/Blaze) not run — existing `successAfterEncounterUpdatesProvisions` test still exercises the enabled (default) path end-to-end but wasn't executed locally

Closes #1196