### PR TITLE
Add Debug Logging For Silent Consent Exclusion Paths In ConsentCalculator

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/torch/consent/ConsentCalculator.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/consent/ConsentCalculator.java
@@ -221,6 +221,7 @@ public class ConsentCalculator {
 
                     Map<TermCode, NonContinuousPeriod> byCode = subtractAndMergeByCode(provisions, consentCodes);
                     if (byCode.isEmpty()) {
+                        logger.debug("Patient {} excluded: required consent codes not fully permitted", patientId);
                         return Stream.empty();
                     }
 
@@ -239,6 +240,7 @@ public class ConsentCalculator {
                         NonContinuousPeriod dataPeriod = intersectConsent(dataByCode);
                         return Stream.of(Map.entry(patientId, dataPeriod));
                     } catch (ConsentViolatedException e) {
+                        logger.debug("Patient {} excluded: {}", patientId, e.getMessage());
                         return Stream.empty();
                     }
                 })


### PR DESCRIPTION
## Summary
- `ConsentCalculator.calculateConsent` had two branches that silently dropped a patient from the batch with no log: the empty `byCode` result (missing/incomplete required consent code) and the caught `ConsentViolatedException` from `intersectConsent` (no periods / non-overlapping periods).
- Added a debug log at each, consistent with the existing gate-check exclusion log at debug level.

Closes #1204

## Test plan
- [x] `mvn -Dtest=ConsentCalculatorTest test` — all pass; confirmed both new debug lines fire (e.g. `Patient patient2 excluded: Consent periods do not overlap`, `Patient p1 excluded: required consent codes not fully permitted`)