### PR TITLE
Add Debug Logging To Reference Resolution And Cascading Delete Pipeline Stages

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/torch/service/ExtractDataService.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/service/ExtractDataService.java
@@ -228,13 +228,17 @@ public class ExtractDataService {
                 .flatMap(patientBatch ->
                         executeAndMeasureAsync(PipelineStage.REFERENCE_RESOLVE, patientBatch.diagnostics(), () ->
                                 referenceResolver.resolvePatientBatch(patientBatch, groupsToProcess.allGroups())))
+                .doOnNext(patientBatch ->
+                        logger.debug("Batch {} resolved references ({} patients)", batchId, patientBatch.patientIds().size()))
                 .map(patientBatch ->
                         executeAndMeasure(PipelineStage.CASCADING_DELETE, patientBatch.diagnostics(), () ->
                                 cascadingDelete.handlePatientBatch(patientBatch, groupsToProcess.allGroups())))
+                .doOnNext(patientBatch ->
+                        logger.debug("Batch {} completed cascading delete ({} patients)", batchId, patientBatch.patientIds().size()))
                 .map(patientBatch ->
                         filterPostCascadeMustHaveViolations(patientBatch, groupsToProcess.directPatientCompartmentGroups()))
                 .doOnNext(loadedBatch ->
-                        logger.debug("Batch resolved references {} with {} patients",batchId, loadedBatch.patientIds().size()))
+                        logger.debug("Batch {} completed must-have filtering ({} patients)", batchId, loadedBatch.patientIds().size()))
                 .map(patientBatch -> {
                     ExtractionPatientBatch transformed = executeAndMeasure(PipelineStage.COPY_REDACT, patientBatch.diagnostics(), () ->
                             batchCopierRedacter.transformBatch(ExtractionPatientBatch.of(patientBatch), groupsToProcess.allGroups()));


### PR DESCRIPTION
## Summary
- `ExtractDataService.processBatchAfterConsent` runs REFERENCE_RESOLVE, CASCADING_DELETE, and must-have filtering with no logging between the DIRECT_LOAD and COPY_REDACT checkpoints, which for large batches can look like a stuck extraction (see #1206).
- Adds one DEBUG log line per step: after reference resolution, after cascading delete, and after must-have filtering (renamed from the old combined message).

## Test plan
- [x] `mvn -o compile`
- [x] `mvn -o -Dtest=ExtractDataServiceTest test` (17 passed)

Closes #1206