### PR TITLE
Move Redundant Per-Resource Debug Logging To Trace Where BatchExclusions Already Captures It

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/torch/service/DirectResourceLoader.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/service/DirectResourceLoader.java
@@ -112,7 +112,7 @@ public class DirectResourceLoader {
         if (allowed) {
             return Mono.just(resource);
         }
-        logger.debug("Consent Violated for Resource {} {}", resource.getResourceType(), resource.getId());
+        logger.trace("Consent Violated for Resource {} {}", resource.getResourceType(), resource.getId());
 
         try {
             String patientID = ResourceUtils.patientId(resource);


### PR DESCRIPTION
## Summary
- `DirectResourceLoader.applyConsent` (`DirectResourceLoader.java:115`) logged at DEBUG for every resource that fails a consent check, immediately duplicating the structured `batchExclusions().addConsentExclusion(...)` call right next to it — ~1 million redundant log lines on a real extraction. Moved that log call to TRACE.
- Audited every other `BatchExclusions`/diagnostics recording call site for the same pattern (a DEBUG log duplicating an adjacent structured record): `ReferenceResolver`, `ReferenceHandler`, `ConsentFetcher`, `CascadingDelete`, `ExtractDataService`, `PatientBatchWithConsent`. None have an adjacent DEBUG log duplicating the record, so no further changes were made.
- Left `ConsentCalculator`'s DEBUG logs (`ConsentCalculator.java:224,231,243`) untouched as instructed — they're the only record of those exclusion paths.

## Test plan
- [x] `mvn -P download-ontology -B -pl . -Dtest=DirectResourceLoaderTest test` — 17/17 tests pass.

Closes #1209