### PR TITLE
Update Onto To V5.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <Hapi.version>8.10.1</Hapi.version>
         <hapi-fhir-core.version>6.10.2</hapi-fhir-core.version>
-        <ontology-tag>v4.1.0</ontology-tag>
+        <ontology-tag>v5.0.0</ontology-tag>
         <netty.version>4.2.15.Final</netty.version>
         <opentelemetry.version>1.62.0</opentelemetry.version>
         <jackson-2-bom.version>2.21.5</jackson-2-bom.version>
@@ -188,7 +188,12 @@
         <dependency>
             <groupId>de.medizininformatik-initiative</groupId>
             <artifactId>sq2cql</artifactId>
-            <version>1.3.0</version>
+            <version>1.4.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
 
         <dependency>

--- a/src/main/java/de/medizininformatikinitiative/torch/config/BaseConfig.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/config/BaseConfig.java
@@ -131,9 +131,10 @@ public class BaseConfig {
 
     @Lazy
     @Bean
-    Translator createCqlTranslator(ObjectMapper jsonUtil, TorchProperties torchProperties) throws IOException {
-        var mappings = jsonUtil.readValue(new File(torchProperties.mappingsFile()), Mapping[].class);
-        var mappingTreeBase = new MappingTreeBase(Arrays.stream(jsonUtil.readValue(new File(torchProperties.conceptTreeFile()), MappingTreeModuleRoot[].class)).toList());
+    Translator createCqlTranslator(TorchProperties torchProperties) throws IOException {
+        var jackson3ObjectMapper = new tools.jackson.databind.ObjectMapper();
+        var mappings = jackson3ObjectMapper.readValue(new File(torchProperties.mappingsFile()), Mapping[].class);
+        var mappingTreeBase = new MappingTreeBase(Arrays.stream(jackson3ObjectMapper.readValue(new File(torchProperties.conceptTreeFile()), MappingTreeModuleRoot[].class)).toList());
 
         return Translator.of(MappingContext.of(
                 Stream.of(mappings)

--- a/src/main/java/de/medizininformatikinitiative/torch/service/CohortQueryService.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/service/CohortQueryService.java
@@ -31,6 +31,7 @@ public class CohortQueryService {
     private static final Logger logger = LoggerFactory.getLogger(CohortQueryService.class);
     private final WebClient webClient;
     private final ObjectMapper objectMapper;
+    private final tools.jackson.databind.ObjectMapper jackson3ObjectMapper;
     private final CqlClient cqlClient;
     private final Translator cqlQueryTranslator;
     private final boolean useCql;
@@ -42,6 +43,7 @@ public class CohortQueryService {
     ) {
         this.webClient = webClient;
         this.objectMapper = new ObjectMapper();
+        this.jackson3ObjectMapper = new tools.jackson.databind.ObjectMapper();
         this.cqlClient = cqlClient;
         this.useCql = useCql;
         this.cqlQueryTranslator = cqlQueryTranslator;
@@ -82,7 +84,8 @@ public class CohortQueryService {
     }
 
     public Mono<List<String>> fetchPatientListUsingCql(AnnotatedCrtdl crtdl) {
-        return Mono.fromCallable(() -> objectMapper.treeToValue(crtdl.cohortDefinition(), StructuredQuery.class))
+        return Mono.fromCallable(() -> jackson3ObjectMapper.readValue(
+                        objectMapper.writeValueAsString(crtdl.cohortDefinition()), StructuredQuery.class))
                 .map(ccdl -> cqlQueryTranslator.toCql(ccdl).print())
                 .flatMapMany(cqlClient::fetchPatientIds)
                 .collectList();
@@ -97,9 +100,10 @@ public class CohortQueryService {
     public Mono<String> translateToCql(JsonNode cohortDefinition) {
         return Mono.fromCallable(() -> {
             try {
-                StructuredQuery sq = objectMapper.treeToValue(cohortDefinition, StructuredQuery.class);
+                StructuredQuery sq = jackson3ObjectMapper.readValue(
+                        objectMapper.writeValueAsString(cohortDefinition), StructuredQuery.class);
                 return cqlQueryTranslator.toCql(sq).print();
-            } catch (JsonProcessingException e) {
+            } catch (JsonProcessingException | tools.jackson.core.JacksonException e) {
                 throw new IllegalArgumentException("Invalid cohort definition: " + e.getMessage(), e);
             }
         });

--- a/src/test/java/de/medizininformatikinitiative/torch/FhirControllerIT.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/FhirControllerIT.java
@@ -160,7 +160,8 @@ class FhirControllerIT {
             String jsonString = new Scanner(fis, StandardCharsets.UTF_8).useDelimiter("\\A").next();
             Crtdl crtdl = objectMapper.readValue(jsonString, Crtdl.class);
 
-            var ccdl = objectMapper.treeToValue(crtdl.cohortDefinition(), StructuredQuery.class);
+            var ccdl = new tools.jackson.databind.ObjectMapper()
+                    .readValue(objectMapper.writeValueAsString(crtdl.cohortDefinition()), StructuredQuery.class);
             Flux<String> patientIds = cqlClient.fetchPatientIds(cqlQueryTranslator.toCql(ccdl).print());
 
             StepVerifier.create(patientIds)


### PR DESCRIPTION
## Summary
- Bump `ontology-tag` from v4.1.0 to v5.0.0 (`fhir-ontology-generator` mapping/StructureDefinition release).
- Bump `sq2cql` from 1.3.0 to 1.4.0: v5.0.0's `mapping_cql.json` emits `instant` as a FHIR type for `Observation.effective`/`DiagnosticReport.issued` time restrictions, which only sq2cql >= 1.4.0 understands (older versions fail app startup entirely, since the mapping array is deserialized eagerly at bean creation).
- sq2cql 1.4.0 itself migrated internally from Jackson 2 to Jackson 3 (`tools.jackson.databind`), so its model classes (`Mapping`, `MappingTreeModuleRoot`, `StructuredQuery`) can no longer be parsed by torch's Jackson 2 `ObjectMapper`. Added a small, self-contained Jackson 3 `ObjectMapper` used only at the two call sites that touch these sq2cql types (`BaseConfig.createCqlTranslator`, `CohortQueryService`). The rest of the app (HTTP bodies, CRTDL parsing, consent handling, etc.) stays on Jackson 2 — this keeps the change scoped to the boundary sq2cql forces rather than migrating the whole app's JSON stack.

## Test plan
- [x] `mvn -P download-ontology -B package -DskipTests` — ontology v5.0.0 downloads/unpacks and the app compiles.
- [x] `mvn -pl . -Dtest=OpenApiGeneratorTest test` — full Spring context (including the CQL translator bean) starts cleanly.
- [x] `mvn -pl . -Dtest=CohortQueryServiceTest test` — CQL translation path (`fetchPatientListUsingCql`, `translateToCql`) exercised against real sq2cql 1.4.0 types.
- [x] `mvn -pl . -Dtest=CrtdlConsentValidatorTest test` — passes in isolation.
- [ ] Full `mvn -P download-ontology -B verify` — not fully green in this sandbox due to pre-existing Testcontainers/Docker resource contention when many Spring-context tests run together (reproduced identically on a clean, unmodified `origin/main` checkout with none of this PR's changes applied — see PR discussion), unrelated to this change.