### PR TITLE
Fix Missing Reference With DAR Creating Malformed Resource

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/torch/util/Redaction.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/util/Redaction.java
@@ -259,12 +259,13 @@ public class Redaction {
             MultiElementContext childContexts = contexts.descend(child.getName());
             List<String> types = getTypes(child, childContexts.workingCodes());
 
+            boolean isExtensionSlot = EXTENSION.equals(child.getName()) || MODIFIER_EXTENSION.equals(child.getName());
             if (child.hasValues()) {
                 if (types.stream().anyMatch(type -> type.contains("Reference"))) {
 
                     handleReference(child, childContexts.allowedReferences(references));
                 }
-                boolean checkSlices = !EXTENSION.equals(child.getName()) && !MODIFIER_EXTENSION.equals(child.getName());
+                boolean checkSlices = !isExtensionSlot;
                 Set<String> matchedSliceIds = checkSlices ? matchedSliceIds(child, childContexts) : Set.of();
                 for (Base value : child.getValues()) {
                     redact(value, childContexts, references);
@@ -275,7 +276,10 @@ public class Redaction {
                     childContexts.missingRequiredSlices(matchedSliceIds)
                             .forEach(slice -> addMissingSlice(baseElement, child, slice, childContexts, references));
                 }
-            } else if (child.getMinCardinality() > 0 || childContexts.required()) {
+            // extension/modifierExtension are handled by the URL-aware pipeline (redactExtensions), not the
+            // generic slice/DAR machinery here: an anonymous Extension has no url of its own and would
+            // serialize as {"url": null, ...} (#1230), which no masked stub can represent.
+            } else if (!isExtensionSlot && (child.getMinCardinality() > 0 || childContexts.required())) {
                 addDataAbsentReason(baseElement, child, types.getFirst(), childContexts, references);
             }
         });

--- a/src/test/java/de/medizininformatikinitiative/torch/util/RedactionTest.java
+++ b/src/test/java/de/medizininformatikinitiative/torch/util/RedactionTest.java
@@ -326,6 +326,28 @@ public class RedactionTest {
         assertThat(fhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(tgt)).isEqualTo(fhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(src));
     }
 
+    /**
+     * Reproduces #1230: a required extension slot with no matching instance must be left absent, not masked
+     * with an anonymous {@code Extension} stub, since that has no url and serializes as {@code "url": null}.
+     */
+    @Test
+    void requiredExtensionSlotIsLeftAbsentRatherThanMaskedWithoutUrl() throws IOException, RedactionException {
+        Condition src = new Condition();
+        Meta meta = new Meta();
+        meta.addProfile("http://example.org/fhir/StructureDefinition/condition-with-required-extension-slot");
+        src.setMeta(meta);
+        src.addExtension(new Extension("http://example.org/fhir/StructureDefinition/optional-ref"));
+
+        StructureDefinitionHandler definitionHandler = new StructureDefinitionHandler(new File("src/test/resources/StructureDefinitions/"), new ResourceReader(integrationTestSetup.fhirContext()));
+        definitionHandler.processDirectory();
+        Redaction redaction = new Redaction(definitionHandler);
+        ExtractionRedactionWrapper wrapper = new ExtractionRedactionWrapper(src.copy(), Set.of("http://example.org/fhir/StructureDefinition/condition-with-required-extension-slot"), Map.of(), new CopyTreeNode("dummy"));
+        DomainResource tgt = redaction.redact(wrapper);
+
+        assertThat(tgt.hasExtension()).isFalse();
+        assertThat(tgt.hasModifierExtension()).isFalse();
+    }
+
     @Nested
     class ConditionTest {
 

--- a/src/test/resources/StructureDefinitions/condition-with-required-extension-slot.json
+++ b/src/test/resources/StructureDefinitions/condition-with-required-extension-slot.json
@@ -1,0 +1,87 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "condition-with-required-extension-slot",
+  "url": "http://example.org/fhir/StructureDefinition/condition-with-required-extension-slot",
+  "version": "1.0.0",
+  "name": "ConditionWithRequiredExtensionSlot",
+  "status": "draft",
+  "date": "2025-07-23",
+  "kind": "resource",
+  "abstract": false,
+  "type": "Condition",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Condition",
+  "derivation": "constraint",
+  "snapshot": {
+    "element": [
+      {
+        "id": "Condition.extension",
+        "path": "Condition.extension",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "value",
+              "path": "url"
+            }
+          ],
+          "rules": "open"
+        },
+        "min": 1,
+        "max": "*"
+      },
+      {
+        "id": "Condition.extension:requiredExt",
+        "path": "Condition.extension",
+        "sliceName": "requiredExt",
+        "min": 1,
+        "max": "1",
+        "type": [
+          {
+            "code": "Extension",
+            "profile": ["http://example.org/fhir/StructureDefinition/required-ext"]
+          }
+        ]
+      },
+      {
+        "id": "Condition.extension:optionalRef",
+        "path": "Condition.extension",
+        "sliceName": "optionalRef",
+        "min": 0,
+        "max": "1",
+        "type": [
+          {
+            "code": "Extension",
+            "profile": ["http://example.org/fhir/StructureDefinition/optional-ref"]
+          }
+        ]
+      },
+      {
+        "id": "Condition.modifierExtension",
+        "path": "Condition.modifierExtension",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "value",
+              "path": "url"
+            }
+          ],
+          "rules": "open"
+        },
+        "min": 1,
+        "max": "*"
+      },
+      {
+        "id": "Condition.modifierExtension:requiredModExt",
+        "path": "Condition.modifierExtension",
+        "sliceName": "requiredModExt",
+        "min": 1,
+        "max": "1",
+        "type": [
+          {
+            "code": "Extension",
+            "profile": ["http://example.org/fhir/StructureDefinition/required-mod-ext"]
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- A sliced `.extension` element with `min=1` on the parent slicing element (propagated from a required named slice, e.g. by the IG publisher) has no valid generic empty form: masking it with a stub `Extension` produces `{"url": null, ...}`, since `HapiFactory.create("Extension")` is a bare `new Extension()` with no url. `Extension.url` is 1..1 in FHIR, so this made the resource invalid.
- Reported against `mii-pr-onko-diagnose-primaertumor`, where `Condition.extension` is `min=1` due to the required `Feststellungsdatum` slice, while the requested-but-optional `ReferenzPrimaerdiagnose` slice gets pruned when its reference doesn't resolve, leaving the extension array empty.
- This isn't Onko-specific: any profile where a required named extension slice propagates `min=1` onto the parent `.extension`/`.modifierExtension` element hits the same path when the requested slice is absent — at least 9 profiles in the onko module alone (`Condition.extension` and `Procedure.extension` on several mamma/prostata/krk/melanom/sozialdienst variants).
- `extension`/`modifierExtension` are already excluded from the generic slice-matching machinery a few lines above in `Redaction.redactChildren` (they're handled by the URL-aware `redactExtensions` pipeline instead). This extends that same exclusion to the generic DAR-stub fallback: an anonymous `Extension` can't represent "masked" without a url, so the slot is left absent rather than fabricated.

## Test plan

- [x] Added `RedactionTest.requiredExtensionSlotIsLeftAbsentRatherThanMaskedWithoutUrl`, reproducing the `min=1`-propagation shape with a minimal synthetic StructureDefinition; confirmed it fails on unpatched code (`hasExtension()` true, malformed `url: null` stub) and passes with the fix.
- [x] Swept existing `RedactTest` fixtures for the malformed shape — none found.
- [x] `mvn -pl . -Dtest=RedactionTest test` — 41 tests pass.
- [x] `mvn -P download-ontology -B package -DskipTests` — builds clean.
- [ ] Not verified against the exact reporter resource (`mii-exa-test-data-onko-diagnose-1` / `mii-pr-onko-diagnose-primaertumor`) — only the underlying mechanism via a synthetic profile that reproduces the same cardinality shape.

Closes #1230