### PR TITLE
Release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+## [v1.0.1] - 2026-08-24
+
+### Added
+
+- Add Encounter Shift Toggle In Consent [#1197](https://github.com/medizininformatik-initiative/torch/pull/1197)
+
+### Changed
+
+- Update hapi to v6.10.2 [#1195](https://github.com/medizininformatik-initiative/torch/pull/1195)
+
+### Fixed
+
+- Fix Missing Reference With DAR Creating Malformed Resource [#1231](https://github.com/medizininformatik-initiative/torch/pull/1231)
+
+
 ## [v1.0.0] - 2026-08-11
 
 ### Fixed

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -178,17 +178,17 @@ For container images, we use cosign to sign images. This allows users to confirm
 pipeline and has not been modified after publication.
 
 ```
-cosign verify "ghcr.io/medizininformatik-initiative/torch:v1.0.0" \
+cosign verify "ghcr.io/medizininformatik-initiative/torch:v1.0.1" \
 --certificate-identity-regexp "https://github.com/medizininformatik-initiative/torch.*" \
 --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
---certificate-github-workflow-ref="refs/tags/v1.0.0" \
+--certificate-github-workflow-ref="refs/tags/v1.0.1" \
 -o text
 ```
 
 The expected output is:
 
 ```
-Verification for ghcr.io/medizininformatik-initiative/torch:v1.0.0 --
+Verification for ghcr.io/medizininformatik-initiative/torch:v1.0.1 --
 The following checks were performed on each of these signatures:
 - The cosign claims were validated
 - Existence of the claims in the transparency log was verified offline
@@ -196,5 +196,5 @@ The following checks were performed on each of these signatures:
 ```
 
 This output ensures that the image was build on the GitHub workflow on the repository
-`medizininformatik-initiative/torch` and tag `v1.0.0`.
+`medizininformatik-initiative/torch` and tag `v1.0.1`.
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>de.medizininformatikinitiative</groupId>
     <artifactId>torch</artifactId>
-    <version>v1.0.0</version>
+    <version>v1.0.1</version>
 
     <properties>
         <maven.compiler.source>21</maven.compiler.source>

--- a/src/main/java/de/medizininformatikinitiative/torch/rest/CapabilityStatementController.java
+++ b/src/main/java/de/medizininformatikinitiative/torch/rest/CapabilityStatementController.java
@@ -52,7 +52,7 @@ public class CapabilityStatementController {
         capabilityStatement.setDate(new java.util.Date());
         capabilityStatement.setFhirVersion(Enumerations.FHIRVersion._4_0_1);
         capabilityStatement.setKind(CapabilityStatement.CapabilityStatementKind.INSTANCE);
-        capabilityStatement.getSoftware().setName("Torch FHIR Server").setVersion("1.0.0");
+        capabilityStatement.getSoftware().setName("Torch FHIR Server").setVersion("1.0.1");
         capabilityStatement.getImplementation().setDescription("Torch FHIR Server Implementation");
         logger.trace("Created basic metadata for CapabilityStatement");
 


### PR DESCRIPTION
## Summary
- Bump version to `v1.0.1` in `pom.xml` and `CapabilityStatementController`
- Update cosign verification examples in `docs/deployment.md` to `v1.0.1`
- Add `v1.0.1` section to `CHANGELOG.md`

Closes milestone [v1.0.1](https://github.com/medizininformatik-initiative/torch/milestone/32):

### Added
- Add Encounter Shift Toggle In Consent #1197 (closes #1196)

### Changed
- Update hapi to v6.10.2 #1195

### Fixed
- Fix Missing Reference With DAR Creating Malformed Resource #1231 (closes #1230)

#1209 was closed by #1216, an internal debug→trace log-level cleanup with no user-visible effect, so it isn't listed as a changelog entry. #1226 was closed as filed against the wrong repository, no code change.

## Test plan
- [x] `mvn compile` — compiles cleanly with only the four version-touching files changed
- [x] Diff scope matches the previous `Release v1.0.0` commit (`CHANGELOG.md`, `docs/deployment.md`, `pom.xml`, `CapabilityStatementController.java`)